### PR TITLE
fix(webrtc): wait for signaling transport when subscribing

### DIFF
--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -9,6 +9,7 @@ const Screenshare = (props) => {
     (state) => state.screenshare.screenshareStream
   );
   const isConnected = useSelector((state) => state.screenshare.isConnected);
+  const signalingTransportOpen = useSelector((state) => state.screenshare.signalingTransportOpen);
 
   // TODO decouple unsubscribe from component lifecycle
   useEffect(() => {
@@ -18,10 +19,10 @@ const Screenshare = (props) => {
   }, []);
 
   useEffect(() => {
-    if (!mediaStreamId) {
+    if (!mediaStreamId && signalingTransportOpen) {
       ScreenshareManager.subscribe();
     }
-  }, [mediaStreamId]);
+  }, [mediaStreamId, signalingTransportOpen]);
 
   if (isConnected && mediaStreamId) {
     return <Styled.ScreenshareStream style={style} streamURL={mediaStreamId} />;

--- a/src/components/video/video-container/index.js
+++ b/src/components/video/video-container/index.js
@@ -7,11 +7,20 @@ import VideoManager from '../../../services/webrtc/video-manager';
 import usePrevious from '../../../hooks/use-previous';
 
 const VideoContainer = (props) => {
-  const { cameraId, userAvatar, userColor, userName, style } = props;
+  const {
+    cameraId,
+    userAvatar,
+    userColor,
+    userName,
+    style,
+  } = props;
   const [showOptions, setShowOptions] = useState(false);
   const prevCameraId = usePrevious(cameraId);
   const mediaStreamId = useSelector(
     (state) => state.video.videoStreams[cameraId]
+  );
+  const signalingTransportOpen = useSelector(
+    (state) => state.video.signalingTransportOpen
   );
 
   // TODO decouple subscribe/unsubscribe from component lifecycle
@@ -25,14 +34,16 @@ const VideoContainer = (props) => {
   }, [cameraId]);
 
   useEffect(() => {
-    if (cameraId && !mediaStreamId) {
-      VideoManager.subscribe(cameraId);
-    }
+    if (signalingTransportOpen) {
+      if (cameraId && !mediaStreamId) {
+        VideoManager.subscribe(cameraId);
+      }
 
-    if (prevCameraId && !cameraId) {
-      VideoManager.unsubscribe(prevCameraId);
+      if (prevCameraId && !cameraId) {
+        VideoManager.unsubscribe(prevCameraId);
+      }
     }
-  }, [cameraId, mediaStreamId]);
+  }, [cameraId, mediaStreamId, signalingTransportOpen]);
 
   const renderVideo = () => {
     if (typeof mediaStreamId === 'string') {


### PR DESCRIPTION
The subscription routines (camera, screenshare) are not waiting for the signaling transport to be properly established before being run. That causes a client crash.

This commit tracks the signaling transport state in the subscription routines.

The ideal solution would be to queue up RPC calls in the media managers themselves and flush them when the socket is open. That will be addressed soon.

Closes https://github.com/mconf/mconf-tracker/issues/916