### PR TITLE
fix(video): check for correct bridge role on unsubscribe

### DIFF
--- a/src/services/webrtc/video-manager.js
+++ b/src/services/webrtc/video-manager.js
@@ -403,11 +403,8 @@ class VideoManager {
   unsubscribe(cameraId) {
     const bridge = this.getBroker(cameraId);
 
-    if (bridge) {
+    if (bridge && bridge.role === 'viewer') {
       bridge.stop();
-    } else {
-      // No bridge/broker. Trailing request, just guarantee everything is cleaned up.
-      store.dispatch(setIsConnected(false));
       this.onRemoteVideoExit(cameraId);
     }
   }


### PR DESCRIPTION
Fixes an issue with published cameras incorrectly dropping after rotating the device or re-ordering the video-list.