### PR TITLE
fix(video): re-create signaling WebSocket if token changes

### DIFF
--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -308,11 +308,11 @@ const SocketConnectionComponent = () => {
       case 'result': {
         // We're resolving a validateAuthToken request
         if (msgObj.id === validateReqId.current) {
+          modules.current = setupModules(ws);
           // FIXME initializeMediaManagers: this is definitely not the place
           // to do this. Remove when socket-connection is properly
           // refactored - prlanzarin
           initializeMediaManagers(meetingData);
-          modules.current = setupModules(ws);
         } else {
           // Probably dealing with a module makeCall/method response
           if (msgObj.collection) {


### PR DESCRIPTION
- Fixes an issue with video calls being reject with UNAUTHORIZED errors on reconnections due to stale session tokens being used in the WS URL.
- Track WS shutdowns via logs.