### PR TITLE
fix: surface client/meteor connection status via StatusBar

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { StatusBar } from 'expo-status-bar';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NavigationContainer } from '@react-navigation/native';
 import { Provider, useDispatch } from 'react-redux';
@@ -9,6 +8,7 @@ import { store } from './src/store/redux/store';
 import DrawerNavigator from './src/components/custom-drawer/drawer-navigator';
 import FullscreenWrapper from './src/components/fullscreen-wrapper';
 import EndSessionScreen from './src/screens/end-session-screen';
+import AppStatusBar from './src/components/status-bar';
 import { injectStore as injectStoreVM } from './src/services/webrtc/video-manager';
 import { injectStore as injectStoreSM } from './src/services/webrtc/screenshare-manager';
 import { injectStore as injectStoreAM } from './src/services/webrtc/audio-manager';
@@ -59,12 +59,10 @@ const AppContent = ({ onLeaveSession, jUrl }) => {
 
 const App = (props) => {
   return (
-    <>
-      <Provider store={store}>
-        <AppContent {...props} />
-      </Provider>
-      <StatusBar style="light" />
-    </>
+    <Provider store={store}>
+      <AppContent {...props} />
+      <AppStatusBar />
+    </Provider>
   );
 };
 

--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-import { StatusBar } from 'expo-status-bar';
 import { ActivityIndicator, View } from 'react-native';
 import Colors from '../../../constants/colors';
 import IconButtonComponent from '../../icon-button';
@@ -22,8 +21,6 @@ const AudioControls = (props) => {
 
   return (
     <>
-      {isConnected && <StatusBar backgroundColor="#00BF6F" style="light" />}
-      {isConnecting && <StatusBar backgroundColor="#FFC845" style="dark" />}
       {isConnected && (
         <IconButtonComponent
           size={buttonSize}

--- a/src/components/status-bar/index.js
+++ b/src/components/status-bar/index.js
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+import { StatusBar } from 'expo-status-bar';
+import Colors from '../../constants/colors';
+
+const AppStatusBar = () => {
+  const audioIsConnected = useSelector((state) => state.audio.isConnected);
+  const audioIsConnecting = useSelector((state) => state.audio.isConnecting);
+  const clientIsDisconnected = useSelector((state) => {
+    return !state.client.connected && (state.client.loggedIn || state.client.loggingIn);
+  });
+  const statusBarConnected = audioIsConnected && !clientIsDisconnected;
+  const statusBarConnecting = audioIsConnecting || clientIsDisconnected;
+  const style = statusBarConnecting ? 'dark' : 'light';
+  const backgroundColor = statusBarConnected
+    ? Colors.statusBarConnected
+    : statusBarConnecting
+      ? Colors.statusBarConnecting
+      : null;
+
+  return (
+    <StatusBar backgroundColor={backgroundColor} style={style} />
+  );
+};
+
+export default AppStatusBar;

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -7,6 +7,8 @@ const Colors = {
   lightGray300: '#667080',
   lightGray400: '#28282D',
   contentLetterboxColor: '#3B4A5C',
+  statusBarConnected: '#00BF6F',
+  statusBarConnecting: '#FFC845',
 };
 
 export default Colors;


### PR DESCRIPTION
- [fix: surface client/meteor connection status via StatusBar](https://github.com/mconf/bbb-mobile-sdk/commit/ceef525cfc00ba46bc5ba917331427b8fad24e53)

Partially: https://github.com/mconf/mconf-tracker/issues/1030

- Connection statuses
  * [x]  Surface online/offline states
