### PR TITLE
fix(fullscreen): content area - change between screenshare/presentation

### DIFF
--- a/src/components/content-area/index.js
+++ b/src/components/content-area/index.js
@@ -6,7 +6,8 @@ import { selectScreenshare } from '../../store/redux/slices/screenshare';
 import { setFocusedElement, setFocusedId, setIsFocused } from '../../store/redux/slices/wide-app/layout';
 
 const ContentArea = (props) => {
-  const { style } = props;
+  const { style, fullscreen } = props;
+
   const slidesStore = useSelector((state) => state.slidesCollection);
   const presentationsStore = useSelector((state) => state.presentationsCollection);
   const screenshare = useSelector(selectScreenshare);
@@ -24,8 +25,8 @@ const ContentArea = (props) => {
     const currentSlideList = Object.values(slidesStore.slidesCollection).filter(
       (obj) => {
         return (
-          obj.current === true &&
-          obj.presentationId === currentPresentation[0]?.id
+          obj.current === true
+          && obj.presentationId === currentPresentation[0]?.id
         );
       }
     );
@@ -33,38 +34,42 @@ const ContentArea = (props) => {
     return imageUri?.replace('/svg/', '/png/');
   }, [presentationsStore, slidesStore]);
 
-  const onClickPresentation = () => {
+  const onClickContentArea = () => {
     dispatch(setIsFocused(true));
     dispatch(setFocusedId(handleSlideAndPresentationActive()));
-    dispatch(setFocusedElement('presentation'));
+    dispatch(setFocusedElement('contentArea'));
     navigation.navigate('FullscreenWrapper');
   };
 
-  const onClickScreenshare = () => {
-    dispatch(setIsFocused(true));
-    // Focused ID is not needed here because the Screenshare component is self contained
-    dispatch(setFocusedId(''));
-    dispatch(setFocusedElement('screenshare'));
-    navigation.navigate('FullscreenWrapper');
-  };
+  // ** Content area views methods **
+  const presentationView = () => (
+    <Styled.Presentation
+      width="100%"
+      height="100%"
+      source={{
+        uri: handleSlideAndPresentationActive(),
+      }}
+    />
+  );
 
-  if (!screenshare) {
+  const screenshareView = () => (
+    <Styled.Screenshare style={style} />
+  );
+
+  // ** return methods **
+  if (fullscreen) {
     return (
-      <Styled.ContentAreaPressable onPress={onClickPresentation}>
-        <Styled.Presentation
-          width="100%"
-          height="100%"
-          source={{
-            uri: handleSlideAndPresentationActive(),
-          }}
-        />
-      </Styled.ContentAreaPressable>
+      <>
+        {!screenshare && presentationView()}
+        {screenshare && screenshareView()}
+      </>
     );
   }
 
   return (
-    <Styled.ContentAreaPressable onPress={onClickScreenshare}>
-      <Styled.Screenshare style={style} />
+    <Styled.ContentAreaPressable onPress={onClickContentArea}>
+      {!screenshare && presentationView()}
+      {screenshare && screenshareView()}
     </Styled.ContentAreaPressable>
   );
 };

--- a/src/components/fullscreen-wrapper/index.js
+++ b/src/components/fullscreen-wrapper/index.js
@@ -39,8 +39,7 @@ const FullscreenWrapper = ({ navigation }) => {
         {layoutStore.focusedElement === 'videoStream' && <Styled.VideoStream streamURL={layoutStore.focusedId} />}
         {layoutStore.focusedElement === 'avatar' && <Styled.UserAvatar source={{ uri: layoutStore.focusedId }} />}
         {layoutStore.focusedElement === 'color' && <Styled.UserColor userColor={layoutStore.focusedId} />}
-        {layoutStore.focusedElement === 'presentation' && <Styled.Presentation source={{ uri: layoutStore.focusedId }} />}
-        {layoutStore.focusedElement === 'screenshare' && <Styled.FullscreenScreenshare />}
+        {layoutStore.focusedElement === 'contentArea' && <Styled.ContentArea fullscreen />}
       </Styled.Wrapper>
       <Styled.CloseFullscreenButton
         icon="fullscreen-exit"

--- a/src/components/fullscreen-wrapper/styles.js
+++ b/src/components/fullscreen-wrapper/styles.js
@@ -2,9 +2,8 @@ import styled from 'styled-components/native';
 import { RTCView } from 'react-native-webrtc';
 import button from '../button';
 import Colors from '../../constants/colors';
-import presentation from '../presentation';
 import iconButton from '../icon-button';
-import Screenshare from '../screenshare';
+import contentArea from '../content-area';
 
 const Container = styled.View`
   position: absolute;
@@ -56,9 +55,7 @@ const UserColor = styled.View`
   overflow: hidden;
 `;
 
-const Presentation = styled(presentation)``;
-
-const FullscreenScreenshare = styled(Screenshare)`
+const ContentArea = styled(contentArea)`
   background-color: none;
 `;
 
@@ -75,7 +72,6 @@ export default {
   Wrapper,
   UserAvatar,
   UserColor,
-  Presentation,
   CloseFullscreenButton,
-  FullscreenScreenshare,
+  ContentArea,
 };

--- a/src/components/presentation/index.js
+++ b/src/components/presentation/index.js
@@ -6,7 +6,7 @@ const Presentation = (props) => {
   const [loading, setLoading] = useState(true);
 
   return (
-    <Styled.PresentationView>
+    <>
       {loading && <Styled.PresentationSkeleton />}
       <Styled.PresentationImage
         source={source}
@@ -14,7 +14,7 @@ const Presentation = (props) => {
         resizeMode="contain"
         onLoadEnd={() => { setLoading(false); }}
       />
-    </Styled.PresentationView>
+    </>
   );
 };
 

--- a/src/components/presentation/styles.js
+++ b/src/components/presentation/styles.js
@@ -1,10 +1,6 @@
 import ContentLoader, { Rect } from 'react-content-loader/native';
 import styled from 'styled-components/native';
 
-const PresentationView = styled.View`
-  display: flex;
-`;
-
 const PresentationImage = styled.Image`
   width: 100%;
   height: 100%;
@@ -27,5 +23,4 @@ const PresentationSkeleton = () => (
 export default {
   PresentationImage,
   PresentationSkeleton,
-  PresentationView,
 };


### PR DESCRIPTION
Modify the fullscreen component to use the content-area component instead of the screenshare and presentation components
Remove the pressable from the content area if it comes from a fullscreen 
Fixes several issues involving screenshare/presentation fullscreen:
  - change presentation slide
  - stop sharing screenshare with maximized presentation
  - start sharing screenshare with maximized presentation
  
  Closes https://github.com/mconf/mconf-tracker/issues/1052