### PR TITLE
fix(notification-bar): queue multiple notifs

### DIFF
--- a/src/components/interactions/index.js
+++ b/src/components/interactions/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { hideNotification, setProfile } from '../../store/redux/slices/wide-app/notification-bar';
+import { showNotificationWithTimeout } from '../../store/redux/slices/wide-app/notification-bar';
 import InteractionsService from './service';
 import IconButtonComponent from '../icon-button';
 import Colors from '../../constants/colors';
@@ -34,10 +34,7 @@ const InteractionsControls = (props) => {
             : 'raiseHand'
         );
         if (!isHandRaised) {
-          dispatch(setProfile('handsUp'));
-          setTimeout(() => {
-            dispatch(hideNotification());
-          }, 5000);
+          dispatch(showNotificationWithTimeout('handsUp'));
         }
       }}
     />

--- a/src/components/notification-bar/index.js
+++ b/src/components/notification-bar/index.js
@@ -13,9 +13,9 @@ const NotificationBar = () => {
 
   const handleIcon = () => {
     switch (notificationBarStore.icon) {
-      case 'hand': 
+      case 'hand':
         return <Avatar.Icon size={36} icon="hand-back-left-outline" />;
-      case 'poll': 
+      case 'poll':
         return <Avatar.Icon size={36} icon="poll" />;
       // other icons...
       default:
@@ -28,12 +28,12 @@ const NotificationBar = () => {
   }
 
   return (
-    <Styled.NotificationsBarPressable 
+    <Styled.NotificationsBarPressable
       onPress={() => {
         if (notificationBarStore.icon === 'poll') {
           navigation.navigate('PollScreen');
         }
-        dispatch(hide())
+        dispatch(hide());
       }}
     >
       {handleIcon()}

--- a/src/components/socket-connection/modules/polls.js
+++ b/src/components/socket-connection/modules/polls.js
@@ -7,7 +7,7 @@ import {
   readyStateChanged,
   cleanupStaleData,
 } from '../../../store/redux/slices/polls';
-import { hideNotification, setProfile } from '../../../store/redux/slices/wide-app/notification-bar';
+import { showNotificationWithTimeout } from '../../../store/redux/slices/wide-app/notification-bar';
 
 const POLLS_TOPIC = 'polls';
 
@@ -23,10 +23,7 @@ export class PollsModule extends Module {
         pollObject: msgObj,
       })
     );
-    store.dispatch(setProfile('pollStarted'));
-    return setTimeout(() => {
-      store.dispatch(hideNotification());
-    }, 5000);
+    store.dispatch(showNotificationWithTimeout('pollStarted'));
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/store/redux/slices/wide-app/notification-bar.js
+++ b/src/store/redux/slices/wide-app/notification-bar.js
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 const initialState = {
   isShow: false,
@@ -28,23 +28,44 @@ const notificationBarSlice = createSlice({
     // notification profiles
     setProfile: (state, action) => {
       switch (action.payload) {
-        case'handsUp': 
+        case 'handsUp':
           state.isShow = true;
           state.messageTitle = 'Você levantou a mão';
           state.messageSubtitle = 'os moderadores foram notificados';
           state.icon = 'hand';
-          break
-        case'pollStarted': 
+          break;
+        case 'pollStarted':
           state.isShow = true;
           state.messageTitle = 'Uma enquete foi iniciada';
           state.messageSubtitle = 'Clique aqui para responder';
           state.icon = 'poll';
-          break
+          break;
         default:
       }
     }
   },
 });
+
+const notificationQueue = [];
+export const showNotificationWithTimeout = createAsyncThunk(
+  'notificationBar/setProfile',
+  async (profile, thunkAPI) => {
+    if (notificationQueue.length === 0) {
+      notificationQueue.push(profile);
+      while (notificationQueue.length !== 0) {
+        // eslint-disable-next-line prefer-destructuring
+        profile = notificationQueue[0];
+        thunkAPI.dispatch(setProfile(profile));
+        // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        notificationQueue.shift();
+        thunkAPI.dispatch(hideNotification());
+      }
+    } else {
+      notificationQueue.push(profile);
+    }
+  }
+);
 
 export const {
   show,


### PR DESCRIPTION
Put notifications in a queue so the timeout when there are multiple notifications is increased.
Added a thunk action to handle the timeout.
Fixed some linting warnings.

Closes https://github.com/mconf/mconf-tracker/issues/1051