### PR TITLE
chore: enable external logging by default

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,7 +13,7 @@
       "level": "debug"
     },
     "external": {
-      "enabled": false,
+      "enabled": true,
       "level": "debug",
       "route": "/html5Log",
       "method": "POST",

--- a/src/services/logger/server-stream.js
+++ b/src/services/logger/server-stream.js
@@ -45,7 +45,8 @@ export class ServerStream {
                                 if (typeof onError === 'function') {
                                     onError.call(this, recs, xhr);
                                 } else {
-                                    console.warn('Browser Bunyan: A server log write failed');
+                                    // Do nothing - muffle the logs for the time being - prlanzarin
+                                    //console.warn('Browser Bunyan: A server log write failed');
                                 }
                             }
                             this.records = {};


### PR DESCRIPTION
- Muffle Bunyan warnings for setups where they arent setup
- Ideally we want to dynamically fetch the log destination URL but we cant do it right now