### PR TITLE
fix(camera): prevent camera re-share loop

### DIFF
--- a/src/components/video/video-controls/index.js
+++ b/src/components/video/video-controls/index.js
@@ -38,7 +38,9 @@ const VideoControls = (props) => {
 
   useEffect(() => {
     if (appState.match(/inactive|background/) && isActive) {
-      setPublishOnActive(true);
+      // Only schedule a re-share if the camera was connected in the first place.
+      // If it's still connecting, just stop it.
+      setPublishOnActive(isConnected);
       VideoManager.unpublish(localCameraId);
     } else if (appState === 'active' && publishOnActive) {
       if (camDisabled) {


### PR DESCRIPTION
The camera unpublish/re-publish effect based on
AppState may cause a share/re-share loop and/or leave the local 
state inconsistent if camera permissions are denied.

That happens due to the fact that a re-share is scheduled even when the 
camera was just connecting when the app transitioned to 
background/inactive. Weirdly enough, camera permission denial or ignore 
(ie closing the alert) sets AppState to "background", which triggers 
a re-share (local state is "connecting"). That causes a loop and leaves the
local cameraId/mediaStream state inconsistent. The re-share should only 
be scheduled if the camera was connected in the first place.

This commit sets the publishOnActive state based on the local isConnected 
state to prevent those two scenarios.