### PR TITLE
fix(ios): enable in-conference notification, keep conference alive on background

### DIFF
--- a/App.js
+++ b/App.js
@@ -121,6 +121,11 @@ const AppContent = ({
             colorized: true,
             smallIcon: 'ic_launcher_foreground',
           },
+          ios: {
+            foregroundPresentationOptions: {
+              banner: false,
+            },
+          }
         };
         notifee.displayNotification(_notification);
         setNotification(_notification);

--- a/App.js
+++ b/App.js
@@ -75,6 +75,9 @@ const AppContent = ({
     if (audioIsConnected) {
       // Start/show the notification foreground service
       const getChannelIdAndDisplayNotification = async () => {
+        // Request permissions (required for iOS)
+        await notifee.requestPermission();
+
         const channelId = await notifee.createChannel({
           id: 'inconference',
           // TODO localization

--- a/ios/bbbmobile/Info.plist
+++ b/ios/bbbmobile/Info.plist
@@ -78,5 +78,11 @@
     <string>Dark</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
+    <key>UIBackgroundModes</key>
+    <array>
+      <string>audio</string>
+      <string>fetch</string>
+      <string>voip</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
- [feat(notification): request ios permission](https://github.com/mconf/bbb-mobile-sdk/commit/be0c8b99f451266f587a48d5ebf5c8c2e7b88343)  
  * iOS needs permission requests to be able to display notifications
- [feat(notification): add params ios notifee](https://github.com/mconf/bbb-mobile-sdk/commit/868263a1ad333d1f4b0f3f5855939b76a7b38906)
  * Do not show heads-up notification 
- [fix(ios): set audio|fetch|voip in UIBackgroundModes](https://github.com/mconf/bbb-mobile-sdk/commit/132f7b8a4033275f864344613aca7c054c34c6e2)
  * Prevents user from being logged out when the app is in the background
  * plist changes need to be added to SDK users as well
  
Closes https://github.com/mconf/mconf-tracker/issues/1074