### PR TITLE
fix: use ActivityIndicator from react-native-paper

### DIFF
--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -1,7 +1,8 @@
 import * as Linking from 'expo-linking';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { ActivityIndicator, Alert, View } from 'react-native';
+import { Alert, View } from 'react-native';
+import { ActivityIndicator } from 'react-native-paper';
 import Colors from '../../../constants/colors';
 import IconButtonComponent from '../../icon-button';
 import AudioManager from '../../../services/webrtc/audio-manager';
@@ -129,7 +130,7 @@ const AudioControls = (props) => {
         />
         <Styled.LoadingWrapper pointerEvents="none">
           <ActivityIndicator
-            size={buttonSize * 2}
+            size={buttonSize * 1.5}
             color={joinAudioIconColor}
             animating={isConnecting}
             hidesWhenStopped

--- a/src/components/video/video-controls/index.js
+++ b/src/components/video/video-controls/index.js
@@ -1,9 +1,8 @@
 import * as Linking from 'expo-linking';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import {
-  ActivityIndicator, Alert, AppState, View
-} from 'react-native';
+import { Alert, AppState, View } from 'react-native';
+import { ActivityIndicator } from 'react-native-paper';
 import IconButtonComponent from '../../icon-button';
 import Colors from '../../../constants/colors';
 import VideoManager from '../../../services/webrtc/video-manager';
@@ -127,7 +126,7 @@ const VideoControls = (props) => {
       />
       <Styled.LoadingWrapper pointerEvents="none">
         <ActivityIndicator
-          size={buttonSize * 2}
+          size={buttonSize * 1.5}
           color={iconColor}
           animating={isConnecting}
           hidesWhenStopped

--- a/src/screens/guest-screen/styles.js
+++ b/src/screens/guest-screen/styles.js
@@ -1,3 +1,4 @@
+import { ActivityIndicator } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
 
@@ -44,7 +45,7 @@ const GuestScreenSubtitle = styled(GuestScreenTextContent)`
   font-size: 18px;
 `;
 
-const WaitingAnimation = styled.ActivityIndicator`
+const WaitingAnimation = styled(ActivityIndicator)`
   padding-bottom: 40px;
 `;
 


### PR DESCRIPTION
The native ActivityIndicator does not provide a consistent UIs for both iOS and Android

Use react-native-paper`s instead since that one seems to be consistent