### PR TITLE
fix: guest is not redirected to conference once allowed

### DIFF
--- a/src/screens/guest-screen/index.js
+++ b/src/screens/guest-screen/index.js
@@ -21,7 +21,7 @@ const GuestScreen = () => {
 
   const probeGuestStatus = async () => {
     try {
-      const { response } = await dispatch(fetchGuestStatus()).unwrap();
+      const { response } = await dispatch(fetchGuestStatus({ logger })).unwrap();
       const {
         lobbyMessage: message,
         positionInWaitingQueue: position

--- a/src/store/redux/slices/wide-app/client.js
+++ b/src/store/redux/slices/wide-app/client.js
@@ -135,7 +135,7 @@ const refreshConnectionStatus = createAsyncThunk(
 const GUEST_WAIT_ENDPOINT = '/bigbluebutton/api/guestWait';
 const fetchGuestStatus = createAsyncThunk(
   'client/fetchGuestStatus',
-  async (_, thunkAPI) => {
+  async ({ logger }, thunkAPI) => {
     const { host, sessionToken } = thunkAPI.getState().client.meetingData;
 
     if (!host || !sessionToken) {
@@ -154,7 +154,7 @@ const fetchGuestStatus = createAsyncThunk(
 
     switch (guestStatus) {
       case 'ALLOW':
-        thunkAPI.dispatch(join(joinUrl));
+        thunkAPI.dispatch(join({ url: joinUrl, logger }));
         break;
       case 'WAIT':
         break;


### PR DESCRIPTION
Internal join thunk parameters were stale, so join was never called on approval

This commit updates the internal join call in fetchGuestStatus to reflect the recent thunk changes - and consequently restores the guest feature