### PR TITLE
fix: prevent unhandled rejection when closing apps, useKeepAwake

### DIFF
--- a/App.js
+++ b/App.js
@@ -281,7 +281,8 @@ const AppContent = ({
 };
 
 const App = (props) => {
-  useKeepAwake();
+  useKeepAwake('ExpoKeepAwakeTag', { suppressDeactivateWarnings: true });
+
   return (
     <Provider store={store}>
       <AppContent {...props} />


### PR DESCRIPTION
A unhandled rejection is being thrown when the app is closed via OS and it stems from useKeepAwake

See expo pull 17319 for a detailed rationale - but tl;dr the rejection is benign and should be suppressed