### PR TITLE
fix(socket): prevent socket crash due to inadequate escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@reduxjs/toolkit": "^1.8.3",
     "axios": "^0.27.2",
     "browser-bunyan": "^1.8.0",
+    "ejson": "^2.2.3",
     "eventemitter2": "^6.4.7",
     "expo": "~45.0.0",
     "expo-application": "~4.1.0",

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -25,6 +25,7 @@ import {
   getRandomAlphanumericWithCaps,
   getRandomAlphanumeric,
   decodeMessage,
+  stringifyDDP,
 } from './utils';
 import 'react-native-url-polyfill/auto';
 import TextInput from '../text-input';
@@ -75,7 +76,7 @@ const TERMINATION_REASONS = [
 ];
 
 const sendMessage = (ws, msgObj) => {
-  const msg = JSON.stringify(msgObj).replace(/"/g, '\\"');
+  const msg = stringifyDDP(msgObj).replace(/"/g, '\\"');
 
   ws.send(`["${msg}"]`);
 };

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -76,7 +76,7 @@ const TERMINATION_REASONS = [
 ];
 
 const sendMessage = (ws, msgObj) => {
-  const msg = stringifyDDP(msgObj).replace(/"/g, '\\"');
+  const msg = stringifyDDP(msgObj).replace(/\\|"/g, (match) => `\\${match}`);
 
   ws.send(`["${msg}"]`);
 };

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -24,7 +24,7 @@ import {
   getRandomDigits,
   getRandomAlphanumericWithCaps,
   getRandomAlphanumeric,
-  decodeMessage,
+  parseDDP,
   stringifyDDP,
 } from './utils';
 import 'react-native-url-polyfill/auto';
@@ -359,12 +359,11 @@ const SocketConnectionComponent = (props) => {
     if (msg === 'o') {
       sendConnectMsg(ws);
     } else {
-      if (msg.startsWith('a')) {
-        msg = msg.substring(1, msg.length);
-      }
-      const msgObj = decodeMessage(msg);
+      if (msg.startsWith('a')) msg = msg.substring(1, msg.length);
 
-      if (Object.keys(msgObj).length) {
+      const msgObj = parseDDP(msg);
+
+      if (msgObj && Object.keys(msgObj).length) {
         processMessage(ws, msgObj, meetingData, modules.current);
       }
     }

--- a/src/components/socket-connection/utils.js
+++ b/src/components/socket-connection/utils.js
@@ -1,3 +1,5 @@
+import EJSON from 'ejson';
+
 // FIXME review random generators - definitely not ideal prlanzarin Jan 24 2023
 const DIGITS = '1234567890';
 const ALPHANUMERIC = 'abcdefghijklmnopqrstuvwxyz1234567890';
@@ -32,10 +34,67 @@ const decodeMessage = (msg) => {
   return msgObj;
 };
 
+// Ported from Meteor
+const _isEmpty = (obj) => {
+  if (obj == null) {
+    return true;
+  }
+
+  if (Array.isArray(obj) || typeof obj === 'string') {
+    return obj.length === 0;
+  }
+
+  for (const key in obj) {
+    if (hasOwn.call(obj, key)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+// Ported from Meteor
+const stringifyDDP = (msg) => {
+  const copy = EJSON.clone(msg);
+
+  if (Object.prototype.hasOwnProperty.call(msg, 'fields')) {
+    const cleared = [];
+
+    Object.keys(msg.fields).forEach((key) => {
+      const value = msg.fields[key];
+
+      if (typeof value === 'undefined') {
+        cleared.push(key);
+        delete copy.fields[key];
+      }
+    });
+
+    if (!_isEmpty(cleared)) {
+      copy.cleared = cleared;
+    }
+
+    if (_isEmpty(copy.fields)) {
+      delete copy.fields;
+    }
+  }
+  ['fields', 'params', 'result'].forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(copy, field)) {
+      copy[field] = EJSON._adjustTypesToJSONValue(copy[field]);
+    }
+  });
+
+  if (msg.id && typeof msg.id !== 'string') {
+    throw new Error('Message id is not a string');
+  }
+
+  return JSON.stringify(copy, 'utf8');
+};
+
 export {
   getRandomDigits,
   getRandomAlphanumeric,
   getRandomAlphanumericWithCaps,
   getRandomHex,
   decodeMessage,
+  stringifyDDP,
 };

--- a/src/components/socket-connection/utils.js
+++ b/src/components/socket-connection/utils.js
@@ -1,38 +1,41 @@
+// FIXME review random generators - definitely not ideal prlanzarin Jan 24 2023
+const DIGITS = '1234567890';
+const ALPHANUMERIC = 'abcdefghijklmnopqrstuvwxyz1234567890';
+const ALPHANUMERIC_WITH_CAPS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+const HEX = 'abcdef1234567890';
+
 const randomFromString = (chars, n) => {
   let result = '';
-  const charsLength = chars.length;
+  const charsLength = typeof n === 'number' && n > 0 ? n : chars.length;
 
-  for (let i = 0; i < charsLength; i++) {
+  for (let i = 0; i < charsLength; i += 1) {
     result += chars.charAt(Math.floor(Math.random() * charsLength));
   }
 
   return result;
-}
+};
 
-const DIGITS = "1234567890";
-const ALPHANUMERIC = "abcdefghijklmnopqrstuvwxyz1234567890";
-const ALPHANUMERIC_WITH_CAPS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-const HEX = "abcdef1234567890";
+const getRandomDigits = (n) => randomFromString(DIGITS, n);
+const getRandomAlphanumeric = (n) => randomFromString(ALPHANUMERIC, n);
+const getRandomAlphanumericWithCaps = (n) => randomFromString(ALPHANUMERIC_WITH_CAPS, n);
+const getRandomHex = (n) => randomFromString(HEX, n);
+const decodeMessage = (msg) => {
+  let msgObj = {};
 
-const MainWebSocketUtil = {
-  getRandomDigits: (n) => randomFromString(DIGITS, n),
-  getRandomAlphanumeric: (n) => randomFromString(ALPHANUMERIC, n),
-  getRandomAlphanumericWithCaps: (n) => randomFromString(ALPHANUMERIC_WITH_CAPS, n),
-  getRandomHex: (n) => randomFromString(HEX, n),
+  try {
+    msgObj = JSON.parse(msg);
+    msgObj = JSON.parse(msgObj[0]);
+  } catch {
+    msgObj = {};
+  }
 
-  decodeMessage: (msg) => {
-    let msgObj = {};
+  return msgObj;
+};
 
-    try {
-      msgObj = JSON.parse(msg);
-      msgObj = JSON.parse(msgObj[0]);
-    } catch {
-      msgObj = {}
-    }
-
-    return msgObj;
-  },
-
-}
-
-module.exports = MainWebSocketUtil;
+export {
+  getRandomDigits,
+  getRandomAlphanumeric,
+  getRandomAlphanumericWithCaps,
+  getRandomHex,
+  decodeMessage,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,6 +3749,11 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+ejson@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/ejson/-/ejson-2.2.3.tgz#2b18c2d8f5d61a5cfc6e3eab72c3343909e7afd2"
+  integrity sha512-hsFvJp6OpGxFRQfBR3PSxFpaPALdHDY+SB3TRbMpLWNhvu8GzLiZutof5+/DFd2QekZo3KyXau75ngdJqQUSrw==
+
 electron-to-chromium@^1.4.147:
   version "1.4.150"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.150.tgz"


### PR DESCRIPTION
- [refactor(socket): address linting issues, use ES6 exports in utils](https://github.com/mconf/bbb-mobile-sdk/commit/bafce67d75e030e3622b5c3304fbd67db6cc2dc8)
- [fix(socket): port Meteor`s DDP encoding](https://github.com/mconf/bbb-mobile-sdk/commit/502f49bed992a7c35e24d4f9dcb2b3a0a61751ce) 
- [fix(socket): port Meteor`s DDP decoding](https://github.com/mconf/bbb-mobile-sdk/pull/119/commits/b8128e8dbb06e2b59057d45f54f5769d63a2e219)
  * Nothing outstanding in 502f49b and b8128e8 - just trying to prevent unexpected failures
  * Forces the stringifying and parsing of messages to follow Meteor`s EJSON pattern
- [fix(socket): escape backslashes](https://github.com/mconf/bbb-mobile-sdk/commit/cd36c1eb402efd690c38ab03b40931a4eacfcb5c) 
  * Unescaped backslashes in conjunction with other previously escaped characters (eg ") were borking the client socke