### PR TITLE
fix(video): move videoUsers select to video-list

### DIFF
--- a/src/components/video/video-list/index.js
+++ b/src/components/video/video-list/index.js
@@ -1,8 +1,11 @@
 import { FlatList } from 'react-native';
+import { useSelector } from 'react-redux';
 import Styled from './styles';
+import { selectSortedVideoUsers } from '../../../store/redux/slices/video-streams';
 
 const VideoList = (props) => {
-  const { videoUsers, style, orientation } = props;
+  const { style, orientation } = props;
+  const videoUsers = useSelector(selectSortedVideoUsers);
 
   const renderVideoListItem = (videoUser) => {
     const { item: vuItem } = videoUser;

--- a/src/screens/classroom-main-screen/index.js
+++ b/src/screens/classroom-main-screen/index.js
@@ -6,11 +6,9 @@ import { setBottomChatOpen } from '../../store/redux/slices/wide-app/chat';
 import { useOrientation } from '../../hooks/use-orientation';
 import Colors from '../../constants/colors';
 import Styled from './styles';
-import { selectSortedVideoUsers } from '../../store/redux/slices/video-streams';
 
 const ClassroomMainScreen = () => {
   // variables
-  const videoUsers = useSelector(selectSortedVideoUsers);
   const loggingIn = useSelector((state) => state.client.sessionState.loggingIn);
   const orientation = useOrientation();
   const [switchLandscapeLayout, setSwitchLandscapeLayout] = useState(false);
@@ -27,7 +25,9 @@ const ClassroomMainScreen = () => {
       <SafeAreaView>
         <Styled.ContainerView>
           <Styled.VideoListContainer>
-            <Styled.VideoList videoUsers={videoUsers} />
+            <Styled.VideoList
+              orientation={orientation}
+            />
           </Styled.VideoListContainer>
 
           <Styled.ContentAreaContainer>
@@ -60,7 +60,6 @@ const ClassroomMainScreen = () => {
               {!switchLandscapeLayout && (
                 <Styled.VideoListContainer orientation={orientation}>
                   <Styled.VideoList
-                    videoUsers={videoUsers}
                     orientation={orientation}
                   />
                 </Styled.VideoListContainer>


### PR DESCRIPTION
Should minimize re-renders - videoUsers is only necessary in video-list and downwards, not the whole screen.
(We probably should start adopting mapStateToProps/contexts as a pattern, though)