### PR TITLE
fix: import react-native-gesture-handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 import Settings from './settings.json';
 


### PR DESCRIPTION
It is a necessary step, may crash app in production even if it works fine in dev
See https://reactnavigation.org/docs/drawer-navigator#installation