### PR TITLE
build: bump react-native-webrtc to 1.106.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "0.17.7",
-    "react-native-webrtc": "1.100.1",
+    "react-native-webrtc": "1.106.1",
     "react-native-webview": "11.18.1",
     "react-redux": "^8.0.2",
     "reconnecting-websocket": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,6 +2173,11 @@ acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
+adm-zip@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -7026,11 +7031,12 @@ react-native-web@0.17.7:
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
 
-react-native-webrtc@1.100.1:
-  version "1.100.1"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc/-/react-native-webrtc-1.100.1.tgz#90ab987dcc92d92441b26499a2e895487e0b18dc"
-  integrity sha512-2dF8HrZWdfrbm1NLso424xgNeGFf4WK5Jlqs7ecVDvCMWHTYVHVwyNt52zx1yiOMEqQWk4edOd4xhWJfUiOvMg==
+react-native-webrtc@1.106.1:
+  version "1.106.1"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc/-/react-native-webrtc-1.106.1.tgz#31b18e8780bb927934ebddb5e03a8168cc6edf3c"
+  integrity sha512-955gqWFdISARz9D4hmnPzKQwpaU+AGqUbU+vBjzLCozUseSJ69tTQg2cShyPCBH6A1rwJQE+mrdjcpkeGbx3pQ==
   dependencies:
+    adm-zip "0.5.9"
     base64-js "1.5.1"
     event-target-shim "6.0.2"
     tar "6.1.11"


### PR DESCRIPTION
- Tentatively compatible with Expo 45
- Still Plan B compatible
- WebRTC M106, bumped usrsctp