### PR TITLE
fix(video): prevent app crash due to undefined WS url, +

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -6,7 +6,7 @@
   "showLanguageScreen": true,
   "clientLog": {
     "server": {
-      "enabled": true,
+      "enabled": false,
       "level": "debug"
     },
     "console": {

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -80,9 +80,9 @@ const sendMessage = (ws, msgObj) => {
     const msg = stringifyDDP(msgObj).replace(/\\|"/g, (match) => `\\${match}`);
     ws.send(`["${msg}"]`);
   } catch (error) {
-    logger.warn({
+    logger.debug({
       logCode: 'main_websocket_send_failure',
-    }, 'Main websocket send failed - enqueue');
+    }, `Main websocket send failed, enqueue=${msgObj.msg || 'Unknown'}`);
   }
 };
 

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -80,9 +80,8 @@ const sendMessage = (ws, msgObj) => {
     const msg = stringifyDDP(msgObj).replace(/\\|"/g, (match) => `\\${match}`);
     ws.send(`["${msg}"]`);
   } catch (error) {
-    logger.debug({
-      logCode: 'main_websocket_send_failure',
-    }, `Main websocket send failed, enqueue=${msgObj.msg || 'Unknown'}`);
+    // eslint-disable-next-line no-console
+    console.warn(`Main websocket send failed, enqueue=${msgObj?.msg || 'Unknown'}`);
   }
 };
 

--- a/src/services/webrtc/peer.js
+++ b/src/services/webrtc/peer.js
@@ -132,7 +132,7 @@ export default class WebRtcPeer extends EventEmitter2 {
     this.logger.debug({
       logCode: 'BBB::WebRtcPeer::signalingstatechange',
       extraInfo: { ...this._logMetadata, signalingState },
-    }, 'BBB::WebRtcPeer::signalingstatechange');
+    }, `BBB::WebRtcPeer::signalingstatechange ${signalingState}`);
     this.emit('signalingstatechange', signalingState);
   }
 
@@ -141,7 +141,7 @@ export default class WebRtcPeer extends EventEmitter2 {
     this.logger.debug({
       logCode: 'BBB::WebRtcPeer::oniceconnectionstatechange',
       extraInfo: { ...this._logMetadata, iceConnectionState },
-    }, 'BBB::WebRtcPeer::oniceconnectionstatechange');
+    }, `BBB::WebRtcPeer::oniceconnectionstatechange, ${iceConnectionState}`);
     this.emit('iceconnectionstatechange', iceConnectionState);
   }
 
@@ -150,7 +150,7 @@ export default class WebRtcPeer extends EventEmitter2 {
     this.logger.debug({
       logCode: 'BBB::WebRtcPeer::onconnectionstatechange',
       extraInfo: { ...this._logMetadata, connectionState },
-    }, 'BBB::WebRtcPeer::onconnectionstatechange');
+    }, `BBB::WebRtcPeer::onconnectionstatechange ${connectionState}`);
     this.emit('connectionstatechange', connectionState);
   }
 
@@ -178,7 +178,7 @@ export default class WebRtcPeer extends EventEmitter2 {
           errorName: error.name,
           errorMessage: error.message,
         },
-      }, 'BBB::WebRtcPeer::mediaStreamFactory - gUM failed');
+      }, `BBB::WebRtcPeer::mediaStreamFactory - gUM failed: ${error.name || error.message}`);
       throw error;
     });
   }
@@ -377,7 +377,7 @@ export default class WebRtcPeer extends EventEmitter2 {
           errorName: error.name,
           errorMessage: error.message,
         },
-      }, 'BBB::WebRtcPeer::processAnswer::setRemoteDescription - failed');
+      }, `BBB::WebRtcPeer::processAnswer::setRemoteDescription - failed = ${error.message || error.name}`);
 
       throw error;
     });
@@ -404,7 +404,7 @@ export default class WebRtcPeer extends EventEmitter2 {
           logCode: 'BBB::WebRtcPeer::processOffer::setRemoteDescription',
           extraInfo: this._logMetadata,
         }, 'BBB::WebRtcPeer::processOffer - Remote description set');
-        return this.peerConnection.createAnswer()
+        return this.peerConnection.createAnswer();
       })
       .then((answer) => {
         this.logger.debug({
@@ -459,7 +459,7 @@ export default class WebRtcPeer extends EventEmitter2 {
           errorName: error.name,
           errorMessage: error.message,
         },
-      }, 'Dispose peer failed');
+      }, `Dispose peer failed = ${error.message || error.name}`);
     }
 
     this.removeAllListeners();

--- a/src/services/webrtc/video-manager.js
+++ b/src/services/webrtc/video-manager.js
@@ -161,8 +161,6 @@ class VideoManager {
       this._onWSClosed();
     }
 
-    this._wsUrl = null;
-
     if (this._pingInterval) {
       clearInterval(this._pingInterval);
       this._pingInterval = null;
@@ -205,8 +203,8 @@ class VideoManager {
         return reject(error);
       };
 
-      this.ws = new ReconnectingWebSocket(wsUrl, [], { connectionTimeout: 4000 });
       this._wsUrl = wsUrl;
+      this.ws = new ReconnectingWebSocket(wsUrl, [], { connectionTimeout: 4000 });
       this.ws.addEventListener('close', this._onWSClosed, { once: true });
       this.ws.addEventListener('error', preloadErrorCatcher);
       this.ws.onopen = () => {
@@ -240,6 +238,7 @@ class VideoManager {
     const role = 'share';
     const brokerOptions = {
       ws: this.ws,
+      wsUrl: this._wsUrl,
       cameraId,
       iceServers: this.iceServers,
       stream: (inputStream && inputStream.active) ? inputStream : undefined,
@@ -297,6 +296,7 @@ class VideoManager {
     const role = 'viewer';
     const brokerOptions = {
       ws: this.ws,
+      wsUrl: this._wsUrl,
       cameraId,
       iceServers: this.iceServers,
       offering: false,


### PR DESCRIPTION
- [fix(video): prevent app crash due to undefined WS url](https://github.com/mconf/bbb-mobile-sdk/commit/ed2ef541b1ad7d792d28bfbf3cc6cf33f1745dbe) 
  * Two issues here:
    - The socket URL was not trickled down to VideoBrokers, which means
    that _if_ they were started without a preloaded socket and tried to
    connect to one, the URL would be undefined. The default behavior of
    the WS lib we're using seems to be crashing in that case :)
    - The socket URL nullified on a "clean" WebSocket closure (which might
    be due to a reconnect). Subsequent WS establishments would not have
    a valid URL - crash again.
- [refactor: make a/v logs a bit more useful](https://github.com/mconf/bbb-mobile-sdk/commit/ca69d52a68b7e1b9065fa2f85141488ea0704b51)
- [fix: disable Meteor logging by default](https://github.com/mconf/bbb-mobile-sdk/pull/367/commits/553499a3e5159e0894d10fa8d76ee596dd5a0dae)
  * [refactor: move Meteor enqueue logs to console](https://github.com/mconf/bbb-mobile-sdk/pull/367/commits/4dee4cbdbfcfa787fece093e0023cce73e5722b8)
    - Doesn't make sense to use the E2E logger for this - prone to spamming and recursiveness if Meteor's server logging is enabled
  * Fixes an app freeze on re-connections

Maybe closes https://github.com/mconf/bbb-mobile-sdk/issues/359
