### PR TITLE
fix(navigation): back handler working inside other screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -103,14 +103,19 @@ const AppContent = ({
   useEffect(() => {
     console.log('FOCUS MOUNTED');
     const onBackPress = () => {
-      Alert.alert(t('app.leaveModal.title'), t('app.leaveModal.desc'), [
-        {
-          text: t('app.settings.main.cancel.label'),
-          onPress: () => {},
-          style: 'cancel',
-        },
-        { text: 'OK', onPress: () => dispatch(leave(api)) },
-      ]);
+      const navigation = navigationRef?.current;
+      if (navigation?.canGoBack()) {
+        navigation?.goBack();
+      } else {
+        Alert.alert(t('app.leaveModal.title'), t('app.leaveModal.desc'), [
+          {
+            text: t('app.settings.main.cancel.label'),
+            onPress: () => { },
+            style: 'cancel',
+          },
+          { text: 'OK', onPress: () => dispatch(leave(api)) },
+        ]);
+      }
 
       return true;
     };


### PR DESCRIPTION
only offer to leave the conference when there is no more screen to go back

closes: https://github.com/mconf/bbb-mobile-sdk/issues/413