### PR TITLE
fix(chat): show link instead of html tags

### DIFF
--- a/src/components/chat/chat-popup/chat-popout-item/index.js
+++ b/src/components/chat/chat-popup/chat-popout-item/index.js
@@ -1,7 +1,15 @@
+import HTMLView from 'react-native-htmlview';
 import Styled from './styles';
 
 const ChatPopupItem = (props) => {
   const { userName, userText, onPress } = props;
+
+  const renderMessage = (message) => {
+    if (/<a\b[^>]*>/.test(message)) {
+      return <HTMLView value={message} />;
+    }
+    return <Styled.UserMessage numberOfLines={1}>{message}</Styled.UserMessage>;
+  };
 
   return (
     <Styled.ContainerPressable onPress={onPress}>
@@ -12,9 +20,7 @@ const ChatPopupItem = (props) => {
             {userName}
           </Styled.UserNameText>
         </Styled.AuthorContainer>
-        <Styled.UserMessage numberOfLines={1}>
-          {userText}
-        </Styled.UserMessage>
+        {renderMessage(userText)}
       </Styled.TextContainer>
     </Styled.ContainerPressable>
   );


### PR DESCRIPTION
### Brief description
Shows links in the pop up chat when it has html tags

### Closes
Close  https://github.com/mconf/bbb-mobile-sdk/issues/578

![image](https://github.com/mconf/bbb-mobile-sdk/assets/91704222/be697d3b-0ec1-4e56-9573-06865fab3636)


