### PR TITLE
fix(audio): do not set MediaStreamTrack.enabled if readyState == ended

### DIFF
--- a/src/services/webrtc/audio-broker.js
+++ b/src/services/webrtc/audio-broker.js
@@ -78,8 +78,19 @@ class AudioBroker extends BaseBroker {
 
     if (localStream) {
       localStream.getAudioTracks().forEach((track) => {
+        // If the track is flagged as ended, this is a trailing request
+        // and we should just ignore it
+        if (track.readyState === 'ended') return;
+
+        // If the track is already in the desired state, skip it
+        // Separate from the above check to prevent accessing the `enabled`
+        // property of a track that is in the 'ended' state (even though
+        // JS will short-circuit the evaluation - paranoia)
+        if (track.enabled === shouldEnable) return;
+
         track.enabled = shouldEnable;
       });
+
       this.muted = !shouldEnable;
 
       return true;


### PR DESCRIPTION
Android's WebRTC implementation throws if MediaStreamTrack.enabled is altered while no native tracks are bound to it, and react-native-webrtc doesn't really catch the error == crash.

Check MediaStreamTrack.readyState before altering MediaStreamTrack.enabled in the hopes of circumventing that crash. If this does not fix the issue, it might be related to the asynchronous cleanup of the input stream's tracks (check onAudioExit) - next step would be to remove that specific cleanup and leave it to the PC.close routine only.

closes: https://github.com/mconf/bbb-mobile-sdk/issues/716