### PR TITLE
fix(whiteboard): don't resize screen when keyboard shows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "react-native-webview": "11.26.0",
         "react-redux": "^8.0.2",
         "reconnecting-websocket": "^4.4.0",
+        "rn-android-keyboard-adjust": "^2.1.2",
         "styled-components": "^5.3.5",
         "url": "^0.11.0",
         "util": "^0.12.4"
@@ -17340,6 +17341,18 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rn-android-keyboard-adjust": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rn-android-keyboard-adjust/-/rn-android-keyboard-adjust-2.1.2.tgz",
+      "integrity": "sha512-pUYiMT7aucw5YnV4geGdalyl6o6rEwRYhDnw2oPQwDym1BZHtmKsxFLupky1Kj2ZNkNKadpEyoyHOElLo+f3sA==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-native-webview": "11.26.0",
     "react-redux": "^8.0.2",
     "reconnecting-websocket": "^4.4.0",
+    "rn-android-keyboard-adjust": "^2.1.2",
     "styled-components": "^5.3.5",
     "url": "^0.11.0",
     "util": "^0.12.4"

--- a/src/screens/whiteboard-screen/index.js
+++ b/src/screens/whiteboard-screen/index.js
@@ -6,6 +6,7 @@ import {
   useEffect, useRef, useState
 } from 'react';
 import axios from 'axios';
+import { setAdjustPan, setAdjustResize } from 'rn-android-keyboard-adjust';
 import logger from '../../services/logger';
 
 const WhiteboardScreen = () => {
@@ -15,6 +16,9 @@ const WhiteboardScreen = () => {
   const webViewRef = useRef();
 
   useEffect(() => {
+    // don't resize screen when keyboard shows
+    setAdjustPan();
+
     const url = new URL(joinUrl);
     const getJoinUrlWithEnforceLayout = `https://${url.host}/bigbluebutton/api/getJoinUrl?sessionToken=${url.searchParams.get('sessionToken')}&enforceLayout=presentationOnly`;
 
@@ -32,6 +36,11 @@ const WhiteboardScreen = () => {
         },
       }, `Unable to get enforceLayout Join URL: ${e.message}`);
     });
+
+    return () => {
+      // restore keyboard default behaviour
+      setAdjustResize();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
-  Adds https://www.npmjs.com/package/rn-android-keyboard-adjust as dependency
- Change keyboard behaviour on whiteboard screen so it don't causes input focus to be lost

- This allows the user to use text and sticky note features of whiteboard, although the keyboard stays over the whiteboard.

Closes https://github.com/mconf/bbb-mobile-sdk/issues/777