### PR TITLE
fix: LiveKit is not disconnected on leave, user eject is unhandled, +

### DIFF
--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -17,7 +17,7 @@ import logger from '../../services/logger';
 import useMeeting from '../../graphql/hooks/useMeeting';
 import { useAudioJoin } from '../../hooks/use-audio-join';
 import useCurrentUser from '../../graphql/hooks/useCurrentUser';
-import { liveKitRoom } from '../../services/livekit';
+import { liveKitRoom, disconnectLiveKitRoom } from '../../services/livekit';
 import { USER_SET_TALKING } from './mutations';
 import SelectiveSubscription from './selective-subscription/index.tsx';
 
@@ -121,6 +121,12 @@ const BBBLiveKitRoom = ({ children }) => {
         });
     }
   }, [sessionToken, host, userId, meetingData, meetingLoading]);
+
+  useEffect(() => {
+    return () => {
+      disconnectLiveKitRoom({ final: true });
+    };
+  }, []);
 
   if (!shouldUseLiveKit) return children;
 

--- a/src/screens/feedback-screen/service.js
+++ b/src/screens/feedback-screen/service.js
@@ -16,6 +16,8 @@ const parseEndReason = (endReason) => {
       return 'app.error.403';
     case 'meetingEnded':
       return 'app.guest.meetingEnded';
+    case 'ejected':
+      return 'app.meeting.logout.ejectedFromMeeting';
     default:
       return 'mobileSdk.error.fallback';
   }

--- a/src/services/livekit/index.js
+++ b/src/services/livekit/index.js
@@ -1,4 +1,8 @@
 import { Room } from 'livekit-client';
+import logger from '../logger';
+import AudioManager from '../webrtc/audio-manager';
+import VideoManager from '../webrtc/video-manager';
+import ScreenshareManager from '../webrtc/screenshare-manager';
 
 export const liveKitRoom = new Room({
   adaptiveStream: true,
@@ -7,6 +11,34 @@ export const liveKitRoom = new Room({
   disconnectOnPageLeave: true,
 });
 
+export const disconnectLiveKitRoom = ({
+  final = false,
+}) => {
+  liveKitRoom.disconnect()
+    .then(() => {
+      logger.debug({
+        logCode: 'livekit_room_destroyed',
+      }, 'LiveKit room destroyed');
+    })
+    .catch((error) => {
+      logger.error({
+        logCode: 'livekit_disconnect_error',
+        extraInfo: {
+          errorCode: error.code,
+          errorMessage: error.message,
+        },
+      }, `LiveKit disconnect error: ${error.message}`);
+    })
+    .finally(() => {
+      if (final) {
+        AudioManager.destroy();
+        VideoManager.destroy();
+        ScreenshareManager.destroy();
+      }
+    });
+};
+
 export default {
+  disconnectLiveKitRoom,
   liveKitRoom,
 };

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -337,7 +337,8 @@ class AudioManager {
   }
 
   onAudioExit(bridge) {
-    if (bridge == null || this.bridge?.clientSessionNumber === bridge.clientSessionNumber) {
+    if ((bridge == null || this.bridge == null)
+      || (this.bridge?.clientSessionNumber === bridge.clientSessionNumber)) {
       store.dispatch(setIsConnected(false));
       store.dispatch(setIsConnecting(false));
       store.dispatch(setIsReconnecting(false));
@@ -345,7 +346,7 @@ class AudioManager {
       this.bridge = null;
     }
 
-    if (this.inputStream && this.inputStream.id === bridge.stream.id) {
+    if (this.inputStream && this.inputStream.id === bridge?.stream?.id) {
       this.inputStream.getTracks().forEach((track) => track.stop());
       this.inputStream = null;
     }


### PR DESCRIPTION
- [fix: notifications are never dismissed on session leave](https://github.com/mconf/bbb-mobile-sdk/commit/35b627159366d1c4690f3675964f6065314de8f4) 
  - Notifications are never dismissed when leaving a session because none of
the dismiss API methods are called when audio is disconnected.
  - Add a dismissAllNotificationsAsync when audio is disconnected so that
the notification is properly removed.
- [fix: LiveKit is not disconnected on leave, user eject is unhandled](https://github.com/mconf/bbb-mobile-sdk/commit/602bbea7366bc6f8dac4df3b9a52009fe77cb3fa) 
  - Disconnect LK's room on the following cases:
    - When LK's main component is unmounted
    - When the leave session callback is called. A new leave session
    factory was added so that a default callback is always present
    and the  API-provided one is called alongside it.
    - Whenever the navigator switches to the feedback screen
  - Additionally, handle user ejection by checking whether an
ejectionReasonCode is present in currentUser.