### PR TITLE
fix(audio): audio incorrectly re-joins on spurious re-render

### DIFF
--- a/src/components/actions-bar/audio-button/index.js
+++ b/src/components/actions-bar/audio-button/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
+import { useCallback, useSelector } from 'react-redux';
 import { useAudioJoin } from '../../../hooks/use-audio-join';
 import AudioManager from '../../../services/webrtc/audio-manager';
 import Styled from './styles';
@@ -17,13 +17,13 @@ const AudioButton = () => {
     return null;
   };
 
-  const onPressHeadphone = () => {
+  const onPressHeadphone = useCallback(() => {
     if (isActive) {
       AudioManager.exitAudio();
     } else {
       joinAudio();
     }
-  };
+  }, [isActive, joinAudio]);
 
   return (
     <Styled.ContainerPressable

--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -93,7 +93,7 @@ const AudioControls = () => {
       // Error is handled, clean it up
       dispatch(setAudioError(null));
     }
-  }, [audioError]);
+  }, [audioError, joinAudio]);
 
   const toggleVoice = useCallback(async (mutedVal) => {
     const userId = currentUserVoiceData?.user_current[0]?.voice?.userId;
@@ -127,15 +127,15 @@ const AudioControls = () => {
     } else {
       toggleVoice();
     }
-  }, [micDisabled, audioPermissionTainted, toggleVoice]);
+  }, [micDisabled, audioPermissionTainted, toggleVoice, joinAudio]);
 
-  const onPressHeadphone = () => {
+  const onPressHeadphone = useCallback(() => {
     if (isActive) {
       AudioManager.exitAudio();
     } else {
       joinAudio();
     }
-  };
+  }, [isActive, joinAudio]);
 
   return (
     <Styled.AudioButtonComponent

--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -152,6 +152,7 @@ const BBBLiveKitRoom = ({ children }) => {
     mainRoomBlockedByBreakout,
     isAudioConnected,
     isAudioConnecting,
+    joinAudio,
   ]);
 
   useEffect(() => {

--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -76,6 +76,8 @@ const BBBLiveKitRoom = ({ children }) => {
   const sessionToken = useSelector((state) => state.client.meetingData.sessionToken);
   const isClientConnected = useSelector((state) => state.client.sessionState.connected);
   const isClientLoggedIn = useSelector((state) => state.client.sessionState.loggedIn);
+  const isAudioConnected = useSelector((state) => state.audio.isConnected);
+  const isAudioConnecting = useSelector(({ audio }) => audio.isConnecting || audio.isReconnecting);
   const mainRoomBlockedByBreakout = useSelector((state) => state.client.sessionState.mainRoomBlockedByBreakout);
   const connectionState = useConnectionState(liveKitRoom);
 
@@ -113,7 +115,6 @@ const BBBLiveKitRoom = ({ children }) => {
       && (audioBridge && cameraBridge && screenShareBridge)
       && isClientConnected
       && isClientLoggedIn
-      && connectionState === ConnectionState.Disconnected
       && !mainRoomBlockedByBreakout
     ) {
       initializeMediaManagers({ audioBridge, cameraBridge, screenShareBridge })
@@ -121,11 +122,15 @@ const BBBLiveKitRoom = ({ children }) => {
           const connectOptions = { autoSubscribe: true };
           const url = host ? `wss://${host}/livekit` : null;
 
-          if (!shouldUseLiveKit) return;
+          if (!shouldUseLiveKit || connectionState !== ConnectionState.Disconnected) return;
 
           return liveKitRoom.connect(url, livekitToken, connectOptions);
         })
-        .then(joinAudio)
+        .then(async () => {
+          if (isAudioConnected || isAudioConnecting) return;
+
+          await joinAudio();
+        })
         .catch((initError) => {
           logger.error({
             logCode: 'media_manager_init_failure',
@@ -140,12 +145,13 @@ const BBBLiveKitRoom = ({ children }) => {
     sessionToken,
     host,
     userId,
-    meetingData,
     meetingLoading,
     isClientConnected,
     isClientLoggedIn,
     connectionState,
     mainRoomBlockedByBreakout,
+    isAudioConnected,
+    isAudioConnecting,
   ]);
 
   useEffect(() => {

--- a/src/hooks/use-audio-join.js
+++ b/src/hooks/use-audio-join.js
@@ -13,12 +13,13 @@ export const useAudioJoin = () => {
   const dispatch = useDispatch();
   const { data: meetingData } = useMeeting();
   const meeting = meetingData?.meeting[0];
+  const disableMic = meeting?.lockSettings?.disableMic;
+  const muteOnStart = meeting?.voiceProp?.muteOnStart;
+  const audioBridge = meeting?.audioBridge;
 
   const joinAudio = useCallback(async () => {
-    const micDisabled = meeting.lockSettings?.disableMic && isLocked();
+    const micDisabled = disableMic && isLocked();
     const transparentListenOnly = true;
-    const muteOnStart = meeting?.voiceProp?.muteOnStart;
-    const audioBridge = meeting?.audioBridge;
 
     if (Platform.OS === 'android' && Platform.Version >= ANDROID_SDK_MIN_BTCONNECT) {
       const checkStatus = await PermissionsAndroid.check(
@@ -54,7 +55,7 @@ export const useAudioJoin = () => {
       }, `Audio published failed: ${error.message}`);
       dispatch(setAudioError(error.name));
     });
-  }, [meeting]);
+  }, [disableMic, muteOnStart, audioBridge]);
 
   return { joinAudio };
 };

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -231,6 +231,9 @@ class AudioManager {
     this._host = host;
     this._sessionToken = sessionToken;
     this.logger = logger;
+
+    if (this.initialized && this.iceServers) return;
+
     this.initialized = true;
     store.dispatch(setAudioManagerInitialized(true));
     try {

--- a/src/services/webrtc/livekit-audio-bridge.ts
+++ b/src/services/webrtc/livekit-audio-bridge.ts
@@ -13,6 +13,7 @@ import {
   type TrackPublishOptions,
 } from 'livekit-client';
 import { liveKitRoom } from '../livekit';
+import MediaStreamUtils from './media-stream-utils';
 
 const BRIDGE_NAME = 'livekit';
 const SENDRECV_ROLE = 'sendrecv';
@@ -378,10 +379,31 @@ export default class LiveKitAudioBridge {
 
       if (this.hasMicrophoneTrack()) await this.unpublish();
 
-      if (inputStream) {
+      if (inputStream && !inputStream.active) {
+        this.logger.warn({
+          logCode: 'livekit_audio_publish_inactive_stream',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+          },
+        }, 'LiveKit: audio stream is inactive, fallback');
+      }
+
+      if (inputStream && inputStream.active) {
         // Get tracks from the stream and publish them. Map into an array of
         // Promise objects and wait for all of them to resolve.
-        const trackPublishers = this.originalStream.getTracks()
+        this.logger.debug({
+          logCode: 'livekit_audio_publish_with_stream',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+          },
+        }, 'LiveKit: publishing audio track with stream');
+        const trackPublishers = inputStream.getTracks()
           .map((track) => {
             return this.liveKitRoom.localParticipant.publishTrack(track, publishOptions);
           });
@@ -393,6 +415,15 @@ export default class LiveKitAudioBridge {
           publishOptions,
         );
         this.originalStream = this.inputStream;
+        this.logger.debug({
+          logCode: 'livekit_audio_publish_without_stream',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            streamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+          },
+        }, 'LiveKit: published audio track without stream');
       }
 
       this.onpublished();
@@ -405,6 +436,8 @@ export default class LiveKitAudioBridge {
           errorStack: (error as Error).stack,
           bridgeName: this.bridgeName,
           role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          streamData: MediaStreamUtils.getStreamData(inputStream || this.originalStream),
         },
       }, 'LiveKit: failed to publish audio track');
       throw error;
@@ -483,6 +516,8 @@ export default class LiveKitAudioBridge {
           errorStack: (error as Error).stack,
           bridgeName: this.bridgeName,
           role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          streamData: MediaStreamUtils.getStreamData(inputStream || this.originalStream),
         },
       }, `LiveKit: activate audio failed: ${(error as Error).message}`);
       throw error;
@@ -492,7 +527,16 @@ export default class LiveKitAudioBridge {
   stop(): Promise<boolean> {
     return this.liveKitRoom.localParticipant.setMicrophoneEnabled(false)
       .then(() => this.unpublish())
-      .then(() => true)
+      .then(() => {
+        this.logger.info({
+          logCode: 'livekit_audio_exit',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            role: this.role,
+          },
+        }, 'LiveKit: audio exited');
+        return true;
+      })
       .catch((error) => {
         this.logger.error({
           logCode: 'livekit_audio_exit_error',

--- a/src/services/webrtc/media-stream-utils.js
+++ b/src/services/webrtc/media-stream-utils.js
@@ -1,0 +1,102 @@
+const stopMediaStreamTracks = (stream) => {
+  if (stream && typeof stream.getTracks === 'function') {
+    stream.getTracks().forEach((track) => {
+      if (typeof track.stop === 'function' && track.readyState !== 'ended') {
+        track.stop();
+        // Manually emit the event as a safeguard; Firefox doesn't fire it when it
+        // should with live MediaStreamTracks...
+        const trackStoppedEvt = new MediaStreamTrackEvent('ended', { track });
+        track.dispatchEvent(trackStoppedEvt);
+      }
+    });
+  }
+};
+
+const getAudioTracks = (stream) => {
+  if (stream) {
+    if (typeof stream.getAudioTracks === 'function') {
+      return stream.getAudioTracks();
+    }
+
+    if (typeof stream.getTracks === 'function') {
+      return stream.getTracks().filter((track) => track.kind === 'audio');
+    }
+  }
+
+  return [];
+};
+
+const getVideoTracks = (stream) => {
+  if (stream) {
+    if (typeof stream.getVideoTracks === 'function') {
+      return stream.getVideoTracks();
+    }
+
+    if (typeof stream.getTracks === 'function') {
+      return stream.getTracks().filter((track) => track.kind === 'video');
+    }
+  }
+
+  return [];
+};
+
+const getDeviceIdFromTrack = (track) => {
+  if (track && typeof track.getSettings === 'function') {
+    const { deviceId } = track.getSettings();
+    return deviceId;
+  }
+  return null;
+};
+
+const extractDeviceIdFromStream = (stream, kind) => {
+  // An empty string is the browser's default...
+  let tracks = [];
+
+  switch (kind) {
+    case 'audio':
+      tracks = getAudioTracks(stream);
+      if (tracks.length === 0) return 'listen-only';
+      return getDeviceIdFromTrack(tracks[0]);
+    case 'video':
+      tracks = getVideoTracks(stream);
+      return getDeviceIdFromTrack(tracks[0]);
+    default: {
+      return null;
+    }
+  }
+};
+
+const getMediaStreamLogData = (stream) => {
+  if (!stream) return { audio: [], video: [] };
+
+  try {
+    const audioTracks = getAudioTracks(stream);
+    const videoTracks = getVideoTracks(stream);
+
+    return {
+      active: stream.active,
+      id: stream.id,
+      audio: audioTracks.map((track) => ({
+        id: track.id,
+        enabled: track.enabled,
+        deviceId: getDeviceIdFromTrack(track),
+        label: track.label,
+      })),
+      video: videoTracks.map((track) => ({
+        id: track.id,
+        enabled: track.enabled,
+        deviceId: getDeviceIdFromTrack(track),
+        label: track.label,
+      })),
+    };
+  } catch (error) {
+    return { audio: [], video: [] };
+  }
+};
+
+export default {
+  stopMediaStreamTracks,
+  getMediaStreamLogData,
+  getVideoTracks,
+  extractDeviceIdFromStream,
+};

--- a/src/services/webrtc/screenshare-manager.js
+++ b/src/services/webrtc/screenshare-manager.js
@@ -140,6 +140,9 @@ class ScreenshareManager {
     this._host = host;
     this._sessionToken = sessionToken;
     this.logger = logger;
+
+    if (this.initialized && this.iceServers) return;
+
     this.initialized = true;
     try {
       this.iceServers = await fetchIceServers(this._getStunFetchURL());

--- a/src/services/webrtc/video-manager.js
+++ b/src/services/webrtc/video-manager.js
@@ -374,6 +374,9 @@ class VideoManager {
     this._host = host;
     this._sessionToken = sessionToken;
     this.logger = logger;
+
+    if (this.initialized && this.iceServers) return;
+
     this.initialized = true;
     try {
       this.iceServers = await fetchIceServers(this._getStunFetchURL());


### PR DESCRIPTION
[fix(audio): audio incorrectly re-joins on spurious re-render](https://github.com/mconf/bbb-mobile-sdk/pull/1029/commits/c3e991a4f0f4ab049e089f3f78840e2c241332d4) 
[c3e991a](https://github.com/mconf/bbb-mobile-sdk/pull/1029/commits/c3e991a4f0f4ab049e089f3f78840e2c241332d4)
- The client is re-rendering some components due to an impure prop being
updated. The offender prop in question is not known right now, but due
to weak checks in the LiveKit component that define when audio should
be automatically activated, it triggered audio re-joins in scenarios
like changing the room's recording state.
- Prevent unexpected audio re-joins by:
  - Taking audio connection states into account in the join use effect
  - Improving how trailing media manager init requests are handled
- Additionally, add an uncommited patch that improves LiveKit's handling
of inactive media stream.

[refactor(audio): trim useAudioJoin props, use it as dep in callers](https://github.com/mconf/bbb-mobile-sdk/pull/1029/commits/6b482e9056bc405a17bc745d1afeec6325f6cdf6) 
[6b482e9](https://github.com/mconf/bbb-mobile-sdk/pull/1029/commits/6b482e9056bc405a17bc745d1afeec6325f6cdf6)
- Trim the useAudioJoin hook dependencies so that it isn't re-created
unnecessarily - i.e.: when the meeting object change any unused prop.
- Additionally, make sure the hook's users call it as a dependency
whenever applicable (either in a useEffect or via a useCallback), so
that we guarantee that no expected behavior is present.