### PR TITLE
fix: broken lock settings causes WebRTC media to fail

### DIFF
--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -5,9 +5,9 @@ import { Alert } from 'react-native';
 import { useMutation, useSubscription } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import { useAudioJoin } from '../../../hooks/use-audio-join';
+import useCurrentUser from '../../../graphql/hooks/useCurrentUser';
+import useMeeting from '../../../graphql/hooks/useMeeting';
 import AudioManager from '../../../services/webrtc/audio-manager';
-import { selectLockSettingsProp } from '../../../store/redux/slices/meeting';
-import { isLocked } from '../../../store/redux/slices/current-user';
 import { setAudioError } from '../../../store/redux/slices/wide-app/audio';
 import logger from '../../../services/logger';
 import Queries from './queries';
@@ -18,12 +18,18 @@ const AudioControls = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { joinAudio } = useAudioJoin();
+  const { data: currentUserData } = useCurrentUser();
+  const { data: meetingData } = useMeeting();
   const isConnected = useSelector((state) => state.audio.isConnected);
   const isConnecting = useSelector(({ audio }) => audio.isConnecting || audio.isReconnecting);
-  const micDisabled = useSelector((state) => selectLockSettingsProp(state, 'disableMic') && isLocked(state));
   const isListenOnly = useSelector((state) => state.audio.isListenOnly);
   const audioError = useSelector((state) => state.audio.audioError);
   const localMutedState = useSelector((state) => state.audio.isMuted);
+  const [userSetMuted] = useMutation(Queries.USER_SET_MUTED);
+
+  const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
+  const meetingMicLocked = meetingData?.meeting[0]?.lockSettings?.disableMic;
+  const micDisabled = meetingMicLocked && currentUserLocked;
   const isActive = isConnected || isConnecting;
   const {
     data: currentUserVoiceData,
@@ -31,8 +37,6 @@ const AudioControls = () => {
   } = useSubscription(Queries.USER_CURRENT_VOICE);
   const isMuted = currentUserVoiceData?.user_current[0]?.voice?.muted;
   const unmutedAndConnected = !isMuted && isConnected;
-
-  const [userSetMuted] = useMutation(Queries.USER_SET_MUTED);
 
   useEffect(() => {
     if (!currentUserVoiceLoading && (localMutedState !== isMuted)) {

--- a/src/components/video/video-controls/index.js
+++ b/src/components/video/video-controls/index.js
@@ -3,8 +3,7 @@ import { Alert } from 'react-native';
 import { useMutation } from '@apollo/client';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { selectLockSettingsProp } from '../../../store/redux/slices/meeting';
-import { isLocked } from '../../../store/redux/slices/current-user';
+import useCurrentUser from '../../../graphql/hooks/useCurrentUser';
 import useMeeting from '../../../graphql/hooks/useMeeting';
 import useAppState from '../../../hooks/use-app-state';
 import logger from '../../../services/logger';
@@ -14,16 +13,22 @@ import SFUVideoControls from './sfu-video-controls';
 
 const VideoControlsContainer = () => {
   const { data: meetingData, loading: meetingLoading } = useMeeting();
+  const { data: currentUserData } = useCurrentUser();
   const { t } = useTranslation();
   const [cameraBroadcastStart] = useMutation(Queries.CAMERA_BROADCAST_START);
   const [cameraBroadcastStop] = useMutation(Queries.CAMERA_BROADCAST_STOP);
-  const disabled = useSelector((state) => selectLockSettingsProp(state, 'disableCam') && isLocked(state));
   const isConnected = useSelector((state) => state.video.isConnected);
   const isConnecting = useSelector((state) => state.video.isConnecting);
   const localCameraId = useSelector((state) => state.video.localCameraId);
   const appState = useAppState();
-  const { cameraBridge } = meetingData?.meeting[0] || {};
+
+  const meeting = meetingData?.meeting[0];
+  const meetingCamLocked = meeting?.lockSettings?.disableCam;
+  const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
+  const disabled = meetingCamLocked && currentUserLocked;
+  const { cameraBridge } = meeting || {};
   const buttonEnabled = cameraBridge != null && !meetingLoading;
+
   const sendUserShareWebcam = (cameraId) => {
     return cameraBroadcastStart({ variables: { cameraId } });
   };

--- a/src/hooks/use-audio-join.js
+++ b/src/hooks/use-audio-join.js
@@ -2,23 +2,25 @@ import { useCallback } from 'react';
 import { Platform, PermissionsAndroid } from 'react-native';
 import { useDispatch } from 'react-redux';
 import useMeeting from '../graphql/hooks/useMeeting';
-import { isLocked } from '../store/redux/slices/current-user';
 import { setAudioError } from '../store/redux/slices/wide-app/audio';
 import AudioManager from '../services/webrtc/audio-manager';
 import logger from '../services/logger';
+import useCurrentUser from '../graphql/hooks/useCurrentUser';
 
 const ANDROID_SDK_MIN_BTCONNECT = 31;
 
 export const useAudioJoin = () => {
   const dispatch = useDispatch();
   const { data: meetingData } = useMeeting();
+  const { data: currentUserData } = useCurrentUser();
   const meeting = meetingData?.meeting[0];
   const disableMic = meeting?.lockSettings?.disableMic;
   const muteOnStart = meeting?.voiceProp?.muteOnStart;
   const audioBridge = meeting?.audioBridge;
+  const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
 
   const joinAudio = useCallback(async () => {
-    const micDisabled = disableMic && isLocked();
+    const micDisabled = disableMic && currentUserLocked;
     const transparentListenOnly = true;
 
     if (Platform.OS === 'android' && Platform.Version >= ANDROID_SDK_MIN_BTCONNECT) {

--- a/src/store/redux/slices/current-user.js
+++ b/src/store/redux/slices/current-user.js
@@ -65,11 +65,6 @@ const isPresenter = createSelector(
   (currentUser) => currentUser?.presenter === true
 );
 
-const isLocked = createSelector(
-  [selectCurrentUser],
-  (currentUser) => currentUser?.role !== 'MODERATOR' && currentUser?.locked === true
-);
-
 // Middleware effects and listeners
 const logoutOrEjectionPredicate = (action, currentState) => {
   if (currentState.client.sessionState.ended) return false;
@@ -137,7 +132,6 @@ export {
   selectCurrentUserRole,
   selectCurrentUserId,
   isModerator,
-  isLocked,
   isPresenter,
   logoutOrEjectionPredicate,
   logoutOrEjectionListener,

--- a/src/store/redux/slices/meeting.js
+++ b/src/store/redux/slices/meeting.js
@@ -47,20 +47,6 @@ const selectMeeting = (state) => Object.values(state.meetingCollection.meetingCo
 
 const selectProp = (state, prop) => prop;
 
-const selectAllLockSettingsProps = createSelector(
-  [selectMeeting],
-  (meeting) => {
-    return meeting?.lockSettingsProps ?? {};
-  }
-);
-
-const selectLockSettingsProp = createSelector(
-  [selectAllLockSettingsProps, selectProp],
-  (lockSettings, prop) => {
-    return lockSettings[prop] ?? false;
-  }
-);
-
 const selectAllUsersProps = createSelector(
   [selectMeeting],
   (meeting) => {
@@ -99,8 +85,6 @@ export const {
 
 export {
   selectMeeting,
-  selectAllLockSettingsProps,
-  selectLockSettingsProp,
   selectAllUsersProps,
   selectUsersProp,
   selectAllMetadata,


### PR DESCRIPTION
The way lock settings data is fetched was not migrated to graphql/3.0.
This generates an unhandled exception as it is relying on old Redux data
structures that are not fully available anymore.
That exception causes media initialization to fail whenever a meeting has
lock settings active AND the user is locked.

Migrate lock settings data fetch to GraphQL, restoring lock settings
functionality and fixing the media issues mentioned above.