### PR TITLE
fix(chat): prevent sending empty messages

### DIFF
--- a/src/components/chat/bottom-sheet-chat/index.js
+++ b/src/components/chat/bottom-sheet-chat/index.js
@@ -167,8 +167,11 @@ const BottomSheetChat = () => {
               containerColor={Colors.blue}
               animated
               onPress={() => {
-                setMessageText('');
-                return handleSendMessage(messageText);
+                const trimmedMessage = messageText.trim();
+                if (trimmedMessage) {
+                  handleSendMessage(trimmedMessage);
+                  setMessageText('');
+                }
               }}
             />
           </Styled.SendMessageContainer>


### PR DESCRIPTION
# fix(chat): prevent sending empty messages

## Summary
This pull request prevents users from sending empty or whitespace-only messages in the chat. The send button's logic is updated to validate the message content before dispatching the send action.

## Root cause
The `onPress` handler for the send message button did not check if the input text was empty. It would immediately attempt to send the message and clear the input field, allowing blank messages to be submitted.

## Changes
- Modified the `onPress` handler in `src/components/chat/bottom-sheet-chat/index.js`.
- The message text is now trimmed using `.trim()` to remove leading and trailing whitespace.
- A message is only sent if the resulting string is not empty.
- The text input is only cleared after a valid message has been sent.

## Risk
- **Risk**: Low. This is a minor, self-contained UI logic change.

## Related
- Closes #1085