### PR TITLE
fix: increase restore presentation button size and touch area

### DIFF
--- a/src/components/talking-indicator/styles.js
+++ b/src/components/talking-indicator/styles.js
@@ -37,8 +37,8 @@ const MicIcon = () => (
 
 const IconContainerPresentation = styled(TouchableRipple)`
   margin: 5px;
-  padding: 6px;
-  border-radius: 16px;
+  padding: 12px;
+  border-radius: 24px;
   position: absolute;
   right: 4px;
   background-color: ${Colors.orange};
@@ -52,7 +52,7 @@ const ShowPresentationIcon = ({ onPress, isPresentationOpen }) => {
 
   return (
     <IconContainerPresentation onPress={onPress}>
-      <MaterialIcons name="slideshow" size={16} color="#FFFFFF" />
+      <MaterialIcons name="slideshow" size={24} color="#FFFFFF" />
     </IconContainerPresentation>
   );
 };


### PR DESCRIPTION
## Summary

- Increases the "restore presentation" icon from 16px to 24px (50% larger)
- Increases button padding from 6px to 12px, resulting in a **48dp minimum touch target** (WCAG / Material Design guideline)
- Updates `border-radius` from 16px to 24px to maintain a perfect circle shape with the new proportions

## Test plan

- [ ] Open a session and minimize the presentation
- [ ] Verify the restore presentation button (orange, bottom-right area) is larger and easier to tap
- [ ] Confirm the button still functions correctly (restores presentation on press)
- [ ] Test on both iOS and Android

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)