### PR TITLE
chore: remove back camera option from feedback wishlist

### DIFF
--- a/src/screens/feedback-screen/customFeedback.json
+++ b/src/screens/feedback-screen/customFeedback.json
@@ -395,15 +395,6 @@
       },
       {
         "textLabel": {
-          "id": "app.customFeedback.wish.backCamera"
-        },
-        "type": "radio",
-        "next": "email",
-        "key": "feedback.wish",
-        "value": "backCamera"
-      },
-      {
-        "textLabel": {
           "id": "app.customFeedback.wish.picture"
         },
         "type": "radio",

--- a/src/utils/locales/en.json
+++ b/src/utils/locales/en.json
@@ -18,7 +18,6 @@
   "app.customFeedback.like.chatUx": "The chat",
   "app.customFeedback.like.appUi": "Interface",
   "app.customFeedback.wish.title": "What would you like to see?",
-  "app.customFeedback.wish.backCamera": "Switch to back camera",
   "app.customFeedback.wish.sessionTranscription": "Session Transcript",
   "app.customFeedback.wish.improvedPoll": "Poll experience improvement",
   "app.customFeedback.wish.picture": "Picture-in-Picture",

--- a/src/utils/locales/es.json
+++ b/src/utils/locales/es.json
@@ -18,7 +18,6 @@
   "app.customFeedback.like.chatUx": "El chat",
   "app.customFeedback.like.appUi": "Interfaz",
   "app.customFeedback.wish.title": "¿Qué te gustaría ver?",
-  "app.customFeedback.wish.backCamera": "Cambiar a cámara trasera",
   "app.customFeedback.wish.sessionTranscription": "Transcripción de la sesión",
   "app.customFeedback.wish.improvedPoll": "Mejora en la experiencia de la Encuesta",
   "app.customFeedback.wish.picture": "Picture in Picture",

--- a/src/utils/locales/pt_BR.json
+++ b/src/utils/locales/pt_BR.json
@@ -18,7 +18,6 @@
   "app.customFeedback.like.chatUx": "O chat",
   "app.customFeedback.like.appUi": "Interface",
   "app.customFeedback.wish.title": "O que você gostaria de ver?",
-  "app.customFeedback.wish.backCamera": "Mudar para câmera traseira",
   "app.customFeedback.wish.sessionTranscription": "Transcrição da sessão",
   "app.customFeedback.wish.improvedPoll": "Melhoria na experiência da Enquete",
   "app.customFeedback.wish.picture": "Picture-in-Picture",


### PR DESCRIPTION
Back camera support has already been implemented, so the option no longer makes sense as a user wishlist item in the post-session feedback.

Removes the backCamera entry from customFeedback.json and the corresponding locale keys from pt_BR, en, and es.

Closes #1145