### PR TITLE
feat(livekit): LiveKit as audio state source for Last-N mute, various fixes, +

### DIFF
--- a/src/components/actions-bar/audio-button/index.js
+++ b/src/components/actions-bar/audio-button/index.js
@@ -1,29 +1,39 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useCallback, useSelector } from 'react-redux';
-import { useAudioJoin } from '../../../hooks/use-audio-join';
+import { useDispatch, useSelector } from 'react-redux';
+import { useAudioJoin, invalidateInFlightAudioJoin } from '../../../hooks/use-audio-join';
 import AudioManager from '../../../services/webrtc/audio-manager';
+import {
+  setAudioIntent,
+  setPendingMuteAssert,
+} from '../../../store/redux/slices/wide-app/audio';
 import Styled from './styles';
 import Settings from '../../../../settings.json';
 
 const AudioButton = () => {
   const { t } = useTranslation();
   const { joinAudio } = useAudioJoin();
+  const dispatch = useDispatch();
   const isConnected = useSelector((state) => state.audio.isConnected);
   const isConnecting = useSelector(({ audio }) => audio.isConnecting || audio.isReconnecting);
   const isActive = isConnected || isConnecting;
 
-  if (!Settings.showNotImplementedFeatures) {
-    return null;
-  };
-
   const onPressHeadphone = useCallback(() => {
     if (isActive) {
+      // A voluntary leave clears the mute intent for this meeting: the next join
+      // honors muteOnStart instead of restoring the pre-leave mute state.
+      // Even if leave audio is not available due to LK right now, it should be
+      // once deafening is implemented - so this makes things future proof for now.
+      dispatch(setAudioIntent(null));
+      dispatch(setPendingMuteAssert(null));
+      invalidateInFlightAudioJoin();
       AudioManager.exitAudio();
     } else {
       joinAudio();
     }
   }, [isActive, joinAudio]);
+
+  if (!Settings.showNotImplementedFeatures) return null;
 
   return (
     <Styled.ContainerPressable

--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -35,14 +35,18 @@ const AudioControls = () => {
     data: currentUserVoiceData,
     loading: currentUserVoiceLoading,
   } = useSubscription(Queries.USER_CURRENT_VOICE);
-  const isMuted = currentUserVoiceData?.user_current[0]?.voice?.muted;
+  const voice = currentUserVoiceData?.user_current[0]?.voice;
+  const isMuted = voice?.muted;
   const unmutedAndConnected = !isMuted && isConnected;
 
   useEffect(() => {
-    if (!currentUserVoiceLoading && (localMutedState !== isMuted)) {
-      AudioManager.setMutedState(isMuted);
-    }
-  }, [isMuted, currentUserVoiceLoading, localMutedState]);
+    // Server-client mute reconciliation: skip while the voice record is
+    // absent as it can be nullish on reconnects. Trying this against an absent
+    // voice collection can let to incorrectly unmuting the local mic track.
+    if (currentUserVoiceLoading || !voice) return;
+
+    if (localMutedState !== isMuted) AudioManager.setMutedState(isMuted);
+  }, [isMuted, currentUserVoiceLoading, localMutedState, voice]);
 
   useEffect(() => {
     if (audioError) {

--- a/src/components/audio/audio-controls/index.js
+++ b/src/components/audio/audio-controls/index.js
@@ -1,17 +1,28 @@
 import * as Linking from 'expo-linking';
-import { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 import { Alert } from 'react-native';
 import { useMutation, useSubscription } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
-import { useAudioJoin } from '../../../hooks/use-audio-join';
+import { useAudioJoin, invalidateInFlightAudioJoin } from '../../../hooks/use-audio-join';
 import useCurrentUser from '../../../graphql/hooks/useCurrentUser';
 import useMeeting from '../../../graphql/hooks/useMeeting';
 import AudioManager from '../../../services/webrtc/audio-manager';
-import { setAudioError } from '../../../store/redux/slices/wide-app/audio';
+import {
+  setAudioError,
+  setAudioIntent,
+  setPendingMuteAssert,
+} from '../../../store/redux/slices/wide-app/audio';
 import logger from '../../../services/logger';
 import Queries from './queries';
 import Styled from './styles';
+
+// How long to wait for mute state reconciliation between a local mute assertion
+// vs the server (voice.muted). If convergence is not observed, fall back to
+// the server state for consistency.
+const MUTE_ASSERT_CONVERGENCE_TIMEOUT_MS = 5000;
 
 const AudioControls = () => {
   const [audioPermissionTainted, setAudioPermissionTainted] = useState(false);
@@ -25,7 +36,14 @@ const AudioControls = () => {
   const isListenOnly = useSelector((state) => state.audio.isListenOnly);
   const audioError = useSelector((state) => state.audio.audioError);
   const localMutedState = useSelector((state) => state.audio.isMuted);
+  const pendingMuteAssert = useSelector((state) => state.audio.pendingMuteAssert);
+  const pendingMuteAssertEpoch = useSelector((state) => state.audio.pendingMuteAssertEpoch);
   const [userSetMuted] = useMutation(Queries.USER_SET_MUTED);
+  const reduxStore = useStore();
+  // The Redux epoch when we last fired a mute mutation. Ties to the store's
+  // pendingMuteAssertEpoch.
+  const muteAssertFiredEpoch = useRef(null);
+  const muteAssertTimeout = useRef(null);
 
   const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
   const meetingMicLocked = meetingData?.meeting[0]?.lockSettings?.disableMic;
@@ -39,14 +57,106 @@ const AudioControls = () => {
   const isMuted = voice?.muted;
   const unmutedAndConnected = !isMuted && isConnected;
 
+  // Mute reconciliation effect: applies the server's mute state
+  // locally if it differs from the local state based on specific conditions.
   useEffect(() => {
-    // Server-client mute reconciliation: skip while the voice record is
-    // absent as it can be nullish on reconnects. Trying this against an absent
-    // voice collection can let to incorrectly unmuting the local mic track.
+    // Server-client mute reconciliation has two skip conditions:
+    // - While the voice record is absent as it can be nullish on reconnects.
+    //   Trying this against an absent voice collection can lead to incorrectly
+    //   unmuting the local mic track.
+    // - While a mute re-assert is pending - the restored mute intent must reach the
+    //   server first, or the reconciliation would flip it back to muteOnStart
     if (currentUserVoiceLoading || !voice) return;
+    if (pendingMuteAssert !== null) return;
 
     if (localMutedState !== isMuted) AudioManager.setMutedState(isMuted);
-  }, [isMuted, currentUserVoiceLoading, localMutedState, voice]);
+  }, [isMuted, currentUserVoiceLoading, localMutedState, voice, pendingMuteAssert]);
+
+  // Mute state re-assertion after a rejoin (breakouts, reconnects, etc): once
+  // a rejoined session's voice record exists, push our restored mute intent to the
+  // server so voice.muted converges to it instead of muteOnStart, then let the
+  // reconciliation in the above affect apply the server's verdict locally.
+  // tl;dr: mute(x) -> rejoin -> voice.muted(y) -> assert mute(x) -> voice.muted(x)
+  //        -> AudioManager.setMutedState(x)
+  // Approach here is asymmetric on mute state:
+  // - muted=true: always succeeds server-side, so wait for voice.muted convergence
+  //   before releasing pendingMuteAssert
+  // - muted=false: may be refused (e.g.: lock settings), so release pendingMuteAssert
+  // on the spot and follow the server.
+  useEffect(() => {
+    if (pendingMuteAssert === null) {
+      if (muteAssertTimeout.current) {
+        clearTimeout(muteAssertTimeout.current);
+        muteAssertTimeout.current = null;
+      }
+
+      return;
+    }
+
+    if (currentUserVoiceLoading || !voice) return;
+
+    const epoch = pendingMuteAssertEpoch;
+    const fired = muteAssertFiredEpoch.current === epoch;
+    const isLiveEpoch = () => reduxStore.getState().audio.pendingMuteAssertEpoch === epoch;
+
+    // State convergence is only trusted after our own assert was sent for
+    // whatever was stored latest.
+    // We cannot clear eagerly as a voice record on re-join, at this point, might
+    // be from  the previous cycle, which would be stale and cause assertion to be
+    // cleared incorrectly.
+    // tl;dr: mute(x) -> rejoin -> voice.muted(y) -> assert mute(x) -> voice.muted(x)
+    //        -> clear pendingMuteAssert
+    if (fired && voice.muted === pendingMuteAssert) {
+      dispatch(setPendingMuteAssert(null));
+      return;
+    }
+
+    if (!fired) {
+      muteAssertFiredEpoch.current = epoch;
+
+      userSetMuted({ variables: { muted: pendingMuteAssert, userId: voice.userId } })
+        .then(() => {
+          if (!isLiveEpoch()) return;
+
+          if (pendingMuteAssert === false) {
+            dispatch(setPendingMuteAssert(null));
+          } else {
+            const timer = setTimeout(() => {
+              if (muteAssertTimeout.current === timer) muteAssertTimeout.current = null;
+
+              if (isLiveEpoch()) {
+                logger.warn({
+                  logCode: 'audio_mute_reassert_unconverged',
+                  extraInfo: { pendingMuteAssert },
+                }, 'Mute re-assert did not converge; falling back to server state');
+                dispatch(setPendingMuteAssert(null));
+              }
+            }, MUTE_ASSERT_CONVERGENCE_TIMEOUT_MS);
+
+            muteAssertTimeout.current = timer;
+          }
+        })
+        .catch((error) => {
+          logger.error({
+            logCode: 'audio_mute_reassert_failure',
+            extraInfo: {
+              errorMessage: error?.message,
+              errorStack: error?.stack,
+              pendingMuteAssert
+            },
+          }, `Mute re-assert failed: ${error?.message}`);
+
+          // Fall back to server state (see reconciliation effect above)
+          if (isLiveEpoch()) dispatch(setPendingMuteAssert(null));
+        });
+    }
+  }, [pendingMuteAssert, pendingMuteAssertEpoch, voice, currentUserVoiceLoading]);
+
+  useEffect(() => {
+    return () => {
+      if (muteAssertTimeout.current) clearTimeout(muteAssertTimeout.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (audioError) {
@@ -108,6 +218,9 @@ const AudioControls = () => {
     const currMuted = currentUserVoiceData?.user_current[0]?.voice?.muted;
     const muted = typeof mutedVal === 'boolean' ? mutedVal : !currMuted;
 
+    // Explicit user mute toggle supersedes previous mute asserts
+    dispatch(setPendingMuteAssert(null));
+
     try {
       await userSetMuted({ variables: { muted, userId } });
     } catch (e) {
@@ -139,6 +252,13 @@ const AudioControls = () => {
 
   const onPressHeadphone = useCallback(() => {
     if (isActive) {
+      // A voluntary leave clears the mute intent for this meeting: the next join
+      // honors muteOnStart instead of restoring the pre-leave mute state.
+      // Even if leave audio is not available due to LK right now, it should be
+      // once deafening is implemented - so this makes things future proof for now.
+      dispatch(setAudioIntent(null));
+      dispatch(setPendingMuteAssert(null));
+      invalidateInFlightAudioJoin();
       AudioManager.exitAudio();
     } else {
       joinAudio();

--- a/src/components/livekit/camera/controls/index.js
+++ b/src/components/livekit/camera/controls/index.js
@@ -4,7 +4,7 @@ import {
   useTracks
 } from '@livekit/react-native';
 import { Track } from 'livekit-client';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import useDebounce from '../../../../hooks/use-debounce';
 import { liveKitRoom } from '../../../../services/livekit';
@@ -17,7 +17,7 @@ import {
 import Styled from '../../../video/video-controls/styles';
 import { hideNotification, setProfile, showNotificationWithTimeout } from '../../../../store/redux/slices/wide-app/notification-bar';
 import { getMeetingSettings } from '../../../../graphql/local-states/useMeetingSettings';
-import { getCameraPublishOptions } from '../service';
+import { getCameraCaptureResolution, getCameraPublishOptions } from '../service';
 
 const LKVideoControls = ({
   disabled,
@@ -37,17 +37,15 @@ const LKVideoControls = ({
   const [publishOnActive, setPublishOnActive] = useState(false);
   const isMounted = useRef(false);
   const isActive = localParticipant.isCameraEnabled || isConnecting;
-  const constraints = useMemo(
-    () => (
-      { video: true, facingMode: cameraFacingMode }
-    ),
-    [cameraFacingMode]
-  );
 
   const publishCamera = useCallback(async () => {
     const newCameraId = `${localParticipant.identity}_app_${Date.now()}`;
     const cameraSettings = getMeetingSettings()?.public?.media?.livekit?.camera?.publishOptions;
     const simulcastOptions = getCameraPublishOptions();
+    const captureOptions = {
+      facingMode: cameraFacingMode,
+      resolution: getCameraCaptureResolution(),
+    };
     const publishOptions = {
       dtx: true,
       videoCodec: 'vp8',
@@ -60,7 +58,11 @@ const LKVideoControls = ({
       if (localParticipant.isCameraEnabled) await unpublishCamera();
 
       dispatch(setIsConnecting(true));
-      const localPub = await localParticipant.setCameraEnabled(true, constraints, publishOptions);
+      const localPub = await localParticipant.setCameraEnabled(
+        true,
+        captureOptions,
+        publishOptions,
+      );
 
       if (!localPub) throw new Error('Local track publication failed');
 
@@ -78,7 +80,7 @@ const LKVideoControls = ({
     unpublishCamera,
     sendUserShareWebcam,
     handleCameraPublishError,
-    constraints
+    cameraFacingMode,
   ]);
 
   const unpublishCamera = useCallback(async () => {
@@ -123,7 +125,10 @@ const LKVideoControls = ({
     }
     const localTrack = tracks.find((t) => t.publication?.isLocal)?.publication?.track;
     if (localTrack) {
-      localTrack.restartTrack({ facingMode: cameraFacingMode })
+      localTrack.restartTrack({
+        facingMode: cameraFacingMode,
+        resolution: getCameraCaptureResolution(),
+      });
     }
     dispatch(showNotificationWithTimeout({ profile: 'cameraToggle' }));
 

--- a/src/components/livekit/camera/service.ts
+++ b/src/components/livekit/camera/service.ts
@@ -1,4 +1,4 @@
-import { VideoPreset, type TrackPublishOptions } from 'livekit-client';
+import { VideoPreset, type TrackPublishOptions, type VideoResolution } from 'livekit-client';
 import logger from '../../../services/logger';
 import { getMeetingSettings } from '../../../graphql/local-states/useMeetingSettings';
 import { type CameraProfile, type LiveKitPresetConfig } from '../../../types/meetingClientSettings';
@@ -174,7 +174,16 @@ const resolveExplicitPresets = (
   return deduplicatePresets(resolved, frameRate);
 };
 
-// eslint-disable-next-line import/prefer-default-export
+// The capture resolution to request from @livekit/react-native. The idea is to
+// try and converge capture resolution with the configured default profile
+// (settings.yml provided) Without this, mobile captures at RN's default (h720 = 1280x720).
+// Profiles without explict constraints will fallback to the original default.
+export const getCameraCaptureResolution = (): VideoResolution => {
+  const { width, height, frameRate } = getCameraCaptureSettings(getSelectedCameraProfile());
+
+  return { width, height, frameRate: frameRate ?? DEFAULT_CAM_FPS };
+};
+
 export const getCameraPublishOptions = (): Partial<TrackPublishOptions> => {
   const configPresets = getMeetingSettings()?.public?.media?.livekit?.camera?.presets;
 

--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useMutation } from '@apollo/client';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, useStore } from 'react-redux';
 import {
   LiveKitRoom,
   useLocalParticipant,
@@ -88,6 +88,7 @@ const BBBLiveKitRoom = ({ children }) => {
   const { data: currentUserData } = useCurrentUser();
   const host = useSelector((state) => state.client.meetingData.host);
   const dispatch = useDispatch();
+  const store = useStore();
   const { joinAudio } = useAudioJoin();
   const { data: meetingData, loading: meetingLoading } = useMeeting();
   const sessionToken = useSelector((state) => state.client.meetingData.sessionToken);
@@ -162,7 +163,12 @@ const BBBLiveKitRoom = ({ children }) => {
           return liveKitRoom.connect(url, livekitToken, connectOptions);
         })
         .then(async () => {
-          if (isAudioConnected || isAudioConnecting) return;
+          // Pull audio flags directly from store as this needs to be the latest
+          // state, since multiple locations can trigger this effect with
+          // potentially stale values on React's render cycle.
+          const { isConnected, isConnecting, isReconnecting } = store.getState().audio;
+
+          if (isConnected || isConnecting || isReconnecting) return;
 
           await joinAudio();
         })

--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -104,6 +104,8 @@ const BBBLiveKitRoom = ({ children }) => {
     : null;
   const reconnectOnFatalFailures = meetingSettings?.public?.media?.livekit
     ?.reconnectOnFatalFailures ?? false;
+  const selectiveSubscriptionEnabled = meetingSettings?.public?.media?.livekit
+    ?.selectiveSubscription?.enabled ?? true;
   const fatalReconnectAttempts = useRef(0);
   const fatalReconnectResetTimer = useRef(null);
   const livekitToken = currentUserData?.user_current[0]?.livekit?.livekitToken;
@@ -144,7 +146,16 @@ const BBBLiveKitRoom = ({ children }) => {
     ) {
       initializeMediaManagers({ audioBridge, cameraBridge, screenShareBridge })
         .then(() => {
-          const connectOptions = { autoSubscribe: true };
+          // Selective subscription on mobile is audio only for now. There is no
+          // manual camera/screenshare subscription, so autoSubscribe:false is only
+          // safe when LiveKit carries audio alone. If LiveKit also carries camera or
+          // screenshare, autoSubscribe:false would leave that video unsubscribed
+          // (blank), so keep autoSubscribe:true for now.
+          const usingLiveKitVideo = cameraBridge === 'livekit' || screenShareBridge === 'livekit';
+          const manageAudioSubscriptions = usingAudio
+            && selectiveSubscriptionEnabled
+            && !usingLiveKitVideo;
+          const connectOptions = { autoSubscribe: !manageAudioSubscriptions };
 
           if (!shouldUseLiveKit || connectionState !== ConnectionState.Disconnected) return;
 
@@ -273,7 +284,7 @@ const BBBLiveKitRoom = ({ children }) => {
       style={{ zIndex: 0, height: 'initial', width: 'initial' }}
     >
       <LiveKitObserver room={liveKitRoom} usingAudio={usingAudio} />
-      {usingAudio && <SelectiveSubscription />}
+      {usingAudio && selectiveSubscriptionEnabled && <SelectiveSubscription />}
       {children}
     </LiveKitRoom>
   );

--- a/src/components/livekit/selective-subscription/hooks.ts
+++ b/src/components/livekit/selective-subscription/hooks.ts
@@ -32,6 +32,7 @@ import {
   selectParticipantsToSubscribe,
 } from './service';
 import useCurrentUser from '../../../graphql/hooks/useCurrentUser';
+import useWhoIsUnmuted from '../../../graphql/hooks/useWhoIsUnmuted';
 
 const PARTICIPANTS_UPDATE_FILTER = [
   RoomEvent.ParticipantConnected,
@@ -44,8 +45,6 @@ const PARTICIPANTS_UPDATE_FILTER = [
   RoomEvent.TrackSubscribed,
   RoomEvent.TrackUnsubscribed,
   RoomEvent.TrackSubscriptionFailed,
-  RoomEvent.TrackMuted,
-  RoomEvent.TrackUnmuted,
   RoomEvent.ActiveSpeakersChanged,
 ];
 
@@ -110,11 +109,14 @@ const useParticipantsLastSpokeAt = (room: Room): Map<string, number> => {
 };
 
 /**
- * Provides a debounced mute state for LiveKit participants, derived from the
- * remote participants' own track state.
+ * Provides a debounced unmuted state for the Last-N pool, sourced from
+ * useWhoIsUnmuted (#2515): LiveKit track state or the BBB voice-activity stream,
+ * depending on media.livekit.audio.useLiveKitAudioState. Keyed by
+ * participant.identity; the source may instead key by BBB userId, so lookups
+ * coalesce both (#2607).
  * @param participants - The remote participants
  * @param debounceMs - The debounce time in milliseconds
- * @param enabled - Whether Last-N filtering is active (skips work when not)
+ * @param enabled - Whether Last-N filtering is active (skips work + source when not)
  * @returns A record of participant IDs to their debounced unmuted state
  */
 const useDebouncedMuteState = (
@@ -122,24 +124,9 @@ const useDebouncedMuteState = (
   debounceMs: number = 2500,
   enabled: boolean = true,
 ): Record<string, boolean> => {
-  // Derive the raw unmuted state directly from LiveKit's remote track state:
-  // RemoteTrackPublication.isMuted is delivered via signaling for every
-  // published mic track, subscribed or not, so the Last-N pool needs no extra
-  // server-side (GraphQL) subscription. Keyed by participant.identity to match
-  // the sender set used in handleSubscriptionChanges.
-  const unmutedUsers = useMemo<Record<string, boolean>>(() => {
-    if (!enabled) return {};
-
-    const map: Record<string, boolean> = {};
-
-    participants.forEach((participant) => {
-      const hasUnmutedMic = Array.from(participant.audioTrackPublications.values())
-        .some((pub) => pub.source === Track.Source.Microphone && !pub.isMuted);
-      map[participant.identity] = hasUnmutedMic;
-    });
-
-    return map;
-  }, [participants, enabled]);
+  // Unmuted-users source (#2515): LiveKit track state or the BBB voice-activity
+  // stream. Skipped (no work, no subscription) when Last-N is inactive.
+  const { data: unmutedUsers } = useWhoIsUnmuted({ skip: !enabled });
   const [debouncedState, setDebouncedState] = useState<Record<string, boolean>>({});
   const debouncedStateRef = useRef(debouncedState);
   debouncedStateRef.current = debouncedState;
@@ -150,7 +137,11 @@ const useDebouncedMuteState = (
 
     participants.forEach((participant) => {
       const userId = participant.identity;
-      const currUnmuted = unmutedUsers[userId] ?? false;
+      // useWhoIsUnmuted keys by LK identity (LiveKit source) or BBB userId (voice
+      // stream); dial-in/VO users differ between the two, so check both (#2607).
+      const currUnmuted = unmutedUsers[userId]
+        ?? unmutedUsers[getBbbUserIdForParticipant(participant)]
+        ?? false;
       const prevUnmuted = debouncedStateRef.current[userId] ?? false;
 
       if (currUnmuted === prevUnmuted && !debounceTimers.current.has(userId)) return;

--- a/src/graphql/hooks/useWhoIsUnmuted.ts
+++ b/src/graphql/hooks/useWhoIsUnmuted.ts
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useSubscription, type OnDataOptions } from '@apollo/client';
+import { RoomEvent, Track } from 'livekit-client';
+import { useRemoteParticipants } from '@livekit/react-native';
+import useMeeting from './useMeeting';
+import { getMeetingSettings } from '../local-states/useMeetingSettings';
+import VOICE_ACTIVITY, { type VoiceActivityResponse } from '../queries/voiceActivitySubscription';
+
+type UnmutedUsers = Record<string, boolean>;
+
+export interface UnmutedUsersState {
+  data: UnmutedUsers;
+  loading: boolean;
+}
+
+export interface UseWhoIsUnmutedOptions {
+  // When true, do no work and return an empty map. Used to gate the hook (and its
+  // GraphQL subscription) off when the only consumer — Last-N selective
+  // subscription — is inactive.
+  skip?: boolean;
+}
+
+const BASELINE: UnmutedUsers = Object.freeze({});
+
+// LiveKit-source participant events. Mute/unmute are only observed when LiveKit is
+// the audio-state source; otherwise a minimal filter avoids re-rendering the
+// consumer on every remote mute toggle (the GraphQL source drives it instead).
+const LK_UPDATE_FILTER = [
+  RoomEvent.ParticipantConnected,
+  RoomEvent.ParticipantDisconnected,
+  RoomEvent.TrackPublished,
+  RoomEvent.TrackUnpublished,
+  RoomEvent.TrackMuted,
+  RoomEvent.TrackUnmuted,
+  RoomEvent.Connected,
+];
+const LK_UPDATE_FILTER_MINIMAL = [
+  RoomEvent.ParticipantConnected,
+  RoomEvent.ParticipantDisconnected,
+  RoomEvent.Connected,
+];
+
+/**
+ * Whether the client should derive audio state (who-is-unmuted) from the LiveKit
+ * Room instead of the BBB GraphQL voice-activity stream. Mirrors web's
+ * useShouldUseLiveKitAudioState: the `media.livekit.audio.useLiveKitAudioState`
+ * flag AND audio actually being carried by LiveKit (mobile's analog of web's
+ * `AudioManager._isUsingLiveKit` is `meeting.audioBridge === 'livekit'`).
+ */
+export const useShouldUseLiveKitAudioState = (): boolean => {
+  const { data: meetingData } = useMeeting();
+  const audioBridge = meetingData?.meeting?.[0]?.audioBridge;
+  const useLiveKitAudioState = getMeetingSettings()
+    ?.public?.media?.livekit?.audio?.useLiveKitAudioState ?? false;
+
+  return useLiveKitAudioState && audioBridge === 'livekit';
+};
+
+/**
+ * Mobile port of #2515's audio-state source, consolidated into a single hook
+ * (mobile has no `createReactiveRecordStateHook` machinery and a single consumer,
+ * so the web dispatcher + LiveKit/GraphQL variant files collapse here).
+ *
+ * Returns the set of unmuted users:
+ *   - LiveKit source (`useLiveKitAudioState` on): derived from each participant's
+ *     microphone `RemoteTrackPublication.isMuted`, keyed by `participant.identity`.
+ *   - BBB source (default): accumulated from the canonical
+ *     `user_voice_activity_stream` subscription, keyed by BBB `userId`. Using the
+ *     shared/canonical document keeps Hasura subscription multiplexing intact.
+ *
+ * The two sources key by different ids for dial-in/voice-only users, so consumers
+ * must check both `identity` and the mapped BBB userId (see #2607 coalescing in
+ * selective-subscription/hooks.ts).
+ *
+ * Must be called within the LiveKit RoomContext (its sole consumer,
+ * SelectiveSubscription, is).
+ */
+const useWhoIsUnmuted = ({ skip = false }: UseWhoIsUnmutedOptions = {}): UnmutedUsersState => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const useLiveKitSource = !skip && shouldUseLiveKit;
+  const useGraphqlSource = !skip && !shouldUseLiveKit;
+
+  // --- BBB/GraphQL source: accumulate the canonical voice-activity stream. ---
+  // The stream delivers incremental batches, so merge each into a running map
+  // (unmuted => true; muted => removed to keep it small and isEqual-friendly).
+  // Only mute transitions mutate the map — talking-only batches are ignored so
+  // the frequent talking updates don't churn the consumer.
+  const graphqlUnmutedRef = useRef<UnmutedUsers>({});
+  const [graphqlUnmuted, setGraphqlUnmuted] = useState<UnmutedUsers>({});
+  const onVoiceActivityData = useCallback((options: OnDataOptions<VoiceActivityResponse>) => {
+    const batch = options.data?.data?.user_voice_activity_stream;
+
+    if (!batch?.length) return;
+
+    const next = { ...graphqlUnmutedRef.current };
+    let changed = false;
+
+    batch.forEach(({ userId, muted }) => {
+      if (muted) {
+        if (userId in next) {
+          delete next[userId];
+          changed = true;
+        }
+      } else if (next[userId] !== true) {
+        next[userId] = true;
+        changed = true;
+      }
+    });
+
+    if (!changed) return;
+
+    graphqlUnmutedRef.current = next;
+    setGraphqlUnmuted(next);
+  }, []);
+
+  useSubscription<VoiceActivityResponse>(VOICE_ACTIVITY, {
+    skip: !useGraphqlSource,
+    onData: onVoiceActivityData,
+    // Accumulate via onData only; the stream fires on every talking update, so
+    // let the guarded setState above decide re-renders instead of re-rendering
+    // on each (mostly mute-irrelevant) emission.
+    ignoreResults: true,
+  });
+
+  // --- LiveKit source: derive from remote participants' mic publications. ---
+  const remoteParticipants = useRemoteParticipants({
+    updateOnlyOn: useLiveKitSource ? LK_UPDATE_FILTER : LK_UPDATE_FILTER_MINIMAL,
+  });
+  const liveKitUnmuted = useMemo<UnmutedUsers>(() => {
+    if (!useLiveKitSource) return BASELINE;
+
+    const map: UnmutedUsers = {};
+
+    remoteParticipants.forEach((participant) => {
+      participant.audioTrackPublications.forEach((publication) => {
+        if (publication.source === Track.Source.Microphone && !publication.isMuted) {
+          map[participant.identity] = true;
+        }
+      });
+    });
+
+    return map;
+  }, [useLiveKitSource, remoteParticipants]);
+
+  return useMemo<UnmutedUsersState>(() => {
+    if (skip) return { data: BASELINE, loading: false };
+
+    return {
+      data: shouldUseLiveKit ? liveKitUnmuted : graphqlUnmuted,
+      loading: false,
+    };
+  }, [skip, shouldUseLiveKit, liveKitUnmuted, graphqlUnmuted]);
+};
+
+export default useWhoIsUnmuted;

--- a/src/graphql/local-states/initial-values/meetingClientSettings.ts
+++ b/src/graphql/local-states/initial-values/meetingClientSettings.ts
@@ -702,6 +702,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           },
           unpublishOnMute: false,
           unpublishAfterMuteMs: 5000,
+          useLiveKitAudioState: false,
         },
         camera: {
           publishOptions: {

--- a/src/graphql/queries/meetingSubscription.js
+++ b/src/graphql/queries/meetingSubscription.js
@@ -4,6 +4,7 @@ import { gql } from '@apollo/client';
 const MEETING_SUBSCRIPTION = gql`
   subscription MeetingSubscription {
       meeting {
+        meetingId
         lockSettings {
           disableCam
           disableMic

--- a/src/graphql/queries/voiceActivitySubscription.ts
+++ b/src/graphql/queries/voiceActivitySubscription.ts
@@ -1,0 +1,46 @@
+import { gql } from '@apollo/client';
+
+export interface VoiceActivityResponse {
+  user_voice_activity_stream: Array<{
+    userId: string;
+    voiceUserId: string;
+    talking: boolean;
+    muted: boolean;
+    leftVoiceConf: boolean;
+    user: {
+      color: string;
+      name: string;
+      speechLocale: string | undefined;
+      role: string;
+    };
+  }>;
+}
+
+// This subscription is handled by bbb-graphql-middleware and its content should
+// NOT be modified. The operation name `getUserVoiceStateStream` is matched
+// verbatim by the middleware, which serves it from Redis and multiplexes the
+// stream across all clients (including web). Renaming it (or altering the field
+// set) drops out of that interception and silently falls back to a mobile-only
+// Hasura streaming cohort. Mirrors bbb-html5 core/graphql/queries/voiceActivity.ts.
+export const VOICE_ACTIVITY = gql`
+  subscription getUserVoiceStateStream {
+    user_voice_activity_stream(
+      cursor: { initial_value: { voiceActivityAt: "2020-01-01" } },
+      batch_size: 10
+    ) {
+      userId
+      voiceUserId
+      talking
+      muted
+      leftVoiceConf
+      user {
+        color
+        name
+        speechLocale
+        role
+      }
+    }
+  }
+`;
+
+export default VOICE_ACTIVITY;

--- a/src/hooks/use-audio-join.js
+++ b/src/hooks/use-audio-join.js
@@ -15,7 +15,7 @@ export const useAudioJoin = () => {
   const { data: currentUserData } = useCurrentUser();
   const meeting = meetingData?.meeting[0];
   const disableMic = meeting?.lockSettings?.disableMic;
-  const muteOnStart = meeting?.voiceProp?.muteOnStart;
+  const muteOnStart = meeting?.voiceSettings?.muteOnStart;
   const audioBridge = meeting?.audioBridge;
   const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
 

--- a/src/hooks/use-audio-join.js
+++ b/src/hooks/use-audio-join.js
@@ -1,25 +1,38 @@
 import { useCallback } from 'react';
 import { Platform, PermissionsAndroid } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useStore } from 'react-redux';
 import useMeeting from '../graphql/hooks/useMeeting';
-import { setAudioError } from '../store/redux/slices/wide-app/audio';
+import {
+  setAudioError,
+  setAudioIntent,
+  setMutedState,
+  setPendingMuteAssert,
+} from '../store/redux/slices/wide-app/audio';
 import AudioManager from '../services/webrtc/audio-manager';
 import logger from '../services/logger';
 import useCurrentUser from '../graphql/hooks/useCurrentUser';
 
 const ANDROID_SDK_MIN_BTCONNECT = 31;
 
+let joinInFlight = null;
+
+export const invalidateInFlightAudioJoin = () => {
+  joinInFlight = null;
+};
+
 export const useAudioJoin = () => {
   const dispatch = useDispatch();
+  const store = useStore();
   const { data: meetingData } = useMeeting();
   const { data: currentUserData } = useCurrentUser();
   const meeting = meetingData?.meeting[0];
+  const meetingId = meeting?.meetingId;
   const disableMic = meeting?.lockSettings?.disableMic;
-  const muteOnStart = meeting?.voiceSettings?.muteOnStart;
+  const muteOnStart = meeting?.voiceSettings?.muteOnStart ?? true;
   const audioBridge = meeting?.audioBridge;
   const currentUserLocked = currentUserData?.user_current[0]?.locked ?? false;
 
-  const joinAudio = useCallback(async () => {
+  const doJoinAudio = useCallback(async () => {
     const micDisabled = disableMic && currentUserLocked;
     const transparentListenOnly = true;
 
@@ -42,11 +55,48 @@ export const useAudioJoin = () => {
       }
     }
 
+    // Initial audio mute state derivation:
+    // - locked/listen-only always joins muted;
+    // - a rejoin in the same meeting/session restores the user's current mute
+    //   intent (Redux audio.isMuted)
+    // - the first join honors muteOnStart.
+    // A restored unmute is instead asserted server-side via pendingMuteAssert
+    // and reconciled with server stat, both in audio-controls
+    const {
+      audio: { isMuted: restoredMute, audioIntentMeetingId, audioIntentSessionToken },
+      client: { meetingData: { sessionToken } },
+    } = store.getState();
+    const intentEstablished = audioIntentMeetingId != null
+      && audioIntentMeetingId === meetingId
+      && audioIntentSessionToken === sessionToken;
+    let joinMuted = muteOnStart;
+
+    if (micDisabled) {
+      joinMuted = true;
+    } else if (intentEstablished) {
+      joinMuted = restoredMute || muteOnStart;
+    }
+
+    dispatch(setPendingMuteAssert(null));
+
     return AudioManager.joinMicrophone({
-      muted: muteOnStart,
+      muted: joinMuted,
       isListenOnly: micDisabled,
       transparentListenOnly,
       audioBridge,
+    }).then(() => {
+      // If the join was cancelled while in progress, skip.
+      if (!AudioManager.bridge) return;
+
+      dispatch(setMutedState(joinMuted));
+
+      if (!micDisabled && meetingId != null) {
+        dispatch(setAudioIntent({ meetingId, sessionToken }));
+
+        if (intentEstablished && restoredMute !== muteOnStart) {
+          dispatch(setPendingMuteAssert(restoredMute));
+        }
+      }
     }).catch((error) => {
       logger.error({
         logCode: 'audio_publish_failure',
@@ -57,7 +107,21 @@ export const useAudioJoin = () => {
       }, `Audio published failed: ${error.message}`);
       dispatch(setAudioError(error.name));
     });
-  }, [disableMic, muteOnStart, audioBridge]);
+  }, [disableMic, muteOnStart, audioBridge, currentUserLocked, meetingId, dispatch, store]);
+
+  const joinAudio = useCallback(() => {
+    if (joinInFlight) return joinInFlight;
+
+    const join = doJoinAudio().finally(() => {
+      // Only detach if this join is still the tracked one. We're relying
+      // on useCallback to equality-check here.
+      if (joinInFlight === join) joinInFlight = null;
+    });
+
+    joinInFlight = join;
+
+    return join;
+  }, [doJoinAudio]);
 
   return { joinAudio };
 };

--- a/src/screens/breakout-room-screen/index.js
+++ b/src/screens/breakout-room-screen/index.js
@@ -4,6 +4,7 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions } from 'react-native';
 import { useOrientation } from '../../hooks/use-orientation';
+import { invalidateInFlightAudioJoin } from '../../hooks/use-audio-join';
 import AudioManager from '../../services/webrtc/audio-manager';
 import VideoManager from '../../services/webrtc/video-manager';
 import { disconnectLiveKitRoom } from '../../services/livekit';
@@ -111,6 +112,8 @@ const BreakoutRoomScreen = () => {
   // ***** FUNCTIONS *****
 
   const joinSession = (breakoutRoomJoinUrl) => {
+    // Entering a breakout cancels any pending main room audio join
+    invalidateInFlightAudioJoin();
     AudioManager.exitAudio();
     VideoManager.unpublish(localCameraId);
     dispatch(setMainRoomBlockedByBreakout(true));

--- a/src/screens/inside-breakout-room-screen/index.js
+++ b/src/screens/inside-breakout-room-screen/index.js
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import BbbBreakoutSdk from 'bbb-breakout-sdk';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
-import { useAudioJoin } from '../../hooks/use-audio-join';
 import { setMainRoomBlockedByBreakout } from '../../store/redux/slices/wide-app/client';
 
 const InsideBreakoutRoomScreen = (props) => {
@@ -11,7 +10,6 @@ const InsideBreakoutRoomScreen = (props) => {
   const { route } = props;
   const { i18n } = useTranslation();
   const navigation = useNavigation();
-  const { joinAudio } = useAudioJoin();
 
   return (
     <BbbBreakoutSdk
@@ -21,7 +19,6 @@ const InsideBreakoutRoomScreen = (props) => {
           navigation.goBack();
         }
         dispatch(setMainRoomBlockedByBreakout(false));
-        joinAudio();
       }}
       defaultLanguage={i18n.language}
     />

--- a/src/screens/user-join-screen/index.js
+++ b/src/screens/user-join-screen/index.js
@@ -9,7 +9,7 @@ import {
   setConnected,
   setInitialCurrentUser,
   setLoggedIn,
-  setMeetingData,
+  updateMeetingData,
 } from '../../store/redux/slices/wide-app/client';
 import { disconnectLiveKitRoom } from '../../services/livekit';
 import logger from '../../services/logger';
@@ -27,18 +27,18 @@ const UserJoinScreen = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  const meetingData = {
-    meetingID: currentUser?.meeting.meetingId,
-    sessionToken,
-    internalUserID: currentUser?.userId,
-    fullname: currentUser?.name,
-    externUserID: currentUser?.extId,
-    confname: currentUser?.meeting.name,
-    host,
-    joinUrl,
-  };
-
-  dispatch(setMeetingData(meetingData));
+  useEffect(() => {
+    dispatch(updateMeetingData({
+      meetingID: currentUser?.meeting?.meetingId,
+      sessionToken,
+      internalUserID: currentUser?.userId,
+      fullname: currentUser?.name,
+      externUserID: currentUser?.extId,
+      confname: currentUser?.meeting?.name,
+      host,
+      joinUrl,
+    }));
+  }, [currentUser, sessionToken, host, joinUrl]);
 
   const handleDispatchUserJoin = (authToken) => {
     dispatchUserJoin({

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -118,12 +118,8 @@ class AudioManager {
     if (this.isListenOnly) return;
 
     if (this.bridge) {
-      const changed = this.bridge.setSenderTrackEnabled(shouldEnable);
-
-      if (changed) {
-        const newEnabledState = this._getSenderTrackEnabled();
-        store.dispatch(setMutedState(!newEnabledState));
-      }
+      this.bridge.setSenderTrackEnabled(shouldEnable);
+      store.dispatch(setMutedState(!shouldEnable));
     }
   }
 

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -87,7 +87,14 @@ class AudioManager {
   }
 
   async _mediaFactory(constraints = { audio: true }) {
-    if (this.inputStream && this.inputStream.active) return this.inputStream;
+    // Reuse the cached stream only if it still has a live audio track;
+    // otherwise re-acquire, so a dead input track is regenerated rather than
+    // republished forever.
+    const hasLiveAudioTrack = this.inputStream
+      && this.inputStream.active
+      && this.inputStream.getAudioTracks().some((track) => track.readyState === 'live');
+
+    if (hasLiveAudioTrack) return this.inputStream;
 
     const inputStream = await mediaDevices.getUserMedia(constraints);
     this.inputStream = inputStream;
@@ -294,19 +301,36 @@ class AudioManager {
   onAudioJoin(clientSessionNumber) {
     // Ignore the linter - the equality check is supposed to be `==`
     // DO NOT CHANGE - prlanzarin
-    if (clientSessionNumber == this.bridge?.clientSessionNumber) {
+    // Require a live bridge bridge marking audio as connected. This can
+    // also be called by the LiveKitObserver component without a clientSessionNumber
+    // as that ID is irrelevant for LK, so the commanding check here is that
+    // the bridge MUST exist.
+    const accepted = !!this.bridge && clientSessionNumber == this.bridge?.clientSessionNumber;
+
+    if (accepted) {
       store.dispatch(setIsConnected(true));
       store.dispatch(setIsConnecting(false));
       store.dispatch(setIsReconnecting(false));
+      this.logger.info({
+        logCode: 'audio_joined',
+        extraInfo: {
+          clientSessionNumber,
+          role: this.bridge?.role || 'Unknown',
+        },
+      }, `Audio Joined (${clientSessionNumber})`);
+    } else {
+      // Rejected join signals (e.g. the LiveKitObserver's no-arg call landing in
+      // a teardown window where the bridge is already gone) get their own log:
+      // recording them as "Audio Joined" was misleading during log analysis.
+      this.logger.debug({
+        logCode: 'audio_join_ignored',
+        extraInfo: {
+          clientSessionNumber,
+          bridgeSessionNumber: this.bridge?.clientSessionNumber ?? null,
+          hasBridge: this.bridge != null,
+        },
+      }, `Audio join signal ignored (${clientSessionNumber}); no live/matching bridge`);
     }
-
-    this.logger.info({
-      logCode: 'audio_joined',
-      extraInfo: {
-        clientSessionNumber,
-        role: this.bridge?.role || 'Unknown',
-      },
-    }, `Audio Joined (${clientSessionNumber})`);
   }
 
   onAudioReconnecting(bridge) {

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -170,6 +170,10 @@ class AudioManager {
     bridge.onreconnected = () => {
       this.onAudioReconnected(bridge);
     };
+
+    bridge.onmutestatechanged = (muted) => {
+      store.dispatch(setMutedState(muted));
+    };
   }
 
   _deattachProgressListeners(bridge) {
@@ -178,6 +182,7 @@ class AudioManager {
     bridge.onstart = () => {};
     bridge.onreconnecting = () => {};
     bridge.onreconnected = () => {};
+    bridge.onmutestatechanged = () => {};
   }
 
   _initializeBridge({

--- a/src/services/webrtc/livekit-audio-bridge.ts
+++ b/src/services/webrtc/livekit-audio-bridge.ts
@@ -150,6 +150,20 @@ export default class LiveKitAudioBridge {
     }, 'LiveKit: audio published');
   }
 
+  // Overriden by AudioManager. Signals a mute-state change applied to the track
+  // out-of-band (i.e. not via setSenderTrackEnabled, which already syncs Redux),
+  // so the store can be reconciled with the real track state.
+  private onmutestatechanged(muted: boolean): void {
+    this.logger.debug({
+      logCode: 'livekit_audio_mute_state_changed',
+      extraInfo: {
+        bridgeName: this.bridgeName,
+        role: this.role,
+        muted,
+      },
+    }, `LiveKit: mute state changed - ${muted}`);
+  }
+
   private static isMicrophonePublication(publication: TrackPublication): boolean {
     const { source } = publication;
 
@@ -377,19 +391,24 @@ export default class LiveKitAudioBridge {
       },
     }, `LiveKit: reinforcing muted state on local audio track - ${reason}`);
 
-    this.liveKitRoom.localParticipant.setMicrophoneEnabled(false).catch((error) => {
-      this.logger.error({
-        logCode: 'livekit_audio_mute_reinforce_error',
-        extraInfo: {
-          errorMessage: (error as Error)?.message,
-          errorName: (error as Error)?.name,
-          errorStack: (error as Error)?.stack,
-          bridgeName: this.bridgeName,
-          role: this.role,
-          reason,
-        },
-      }, `LiveKit: failed to reinforce muted state - ${(error as Error)?.message}`);
-    });
+    this.liveKitRoom.localParticipant.setMicrophoneEnabled(false)
+      .then(() => {
+        // Keep Redux's mute state in sync with this out-of-band track.
+        this.onmutestatechanged(true);
+      })
+      .catch((error) => {
+        this.logger.error({
+          logCode: 'livekit_audio_mute_reinforce_error',
+          extraInfo: {
+            errorMessage: (error as Error)?.message,
+            errorName: (error as Error)?.name,
+            errorStack: (error as Error)?.stack,
+            bridgeName: this.bridgeName,
+            role: this.role,
+            reason,
+          },
+        }, `LiveKit: failed to reinforce muted state - ${(error as Error)?.message}`);
+      });
   }
 
   private observeLiveKitEvents(): void {

--- a/src/store/redux/slices/voice-call-states.js
+++ b/src/store/redux/slices/voice-call-states.js
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import AudioManager from '../../../services/webrtc/audio-manager';
+import { invalidateInFlightAudioJoin } from '../../../hooks/use-audio-join';
 
 const voiceCallStatesSlice = createSlice({
   name: 'voice-call-states',
@@ -92,6 +93,7 @@ const voiceCallStateChangeListener = (action, listenerApi) => {
       case 'CALL_ENDED':
         if (currentState.audio.isConnected
           || currentState.audio.isConnecting) {
+          invalidateInFlightAudioJoin();
           AudioManager.exitAudio();
         }
         break;

--- a/src/store/redux/slices/wide-app/audio.js
+++ b/src/store/redux/slices/wide-app/audio.js
@@ -11,7 +11,19 @@ const initialState = {
   inputStreamId: null,
   audioError: null,
   audioDevices: [],
-  selectedAudioDevice: ''
+  selectedAudioDevice: '',
+  // Mute intent persistence keys to restore the user's previous choice of mute state
+  // on select scenarios (breakout exit, reconnects etc). These serve as an
+  // extra safety measure to prevent mute states from leaking across meetings
+  // (store being flushed is not reliable as history has shown); and from leaking
+  // across sessions (full reconnects).
+  audioIntentMeetingId: null,
+  audioIntentSessionToken: null,
+  // Mute value to assert on the server via USER_SET_MUTED once a rejoin's voice
+  // record exists. null = no assertion pending.
+  pendingMuteAssert: null,
+  // Epoch id for pendingMuteAssert, bumped on every setPendingMuteAssert dispatch.
+  pendingMuteAssertEpoch: 0,
 };
 
 const audioSlice = createSlice({
@@ -50,12 +62,23 @@ const audioSlice = createSlice({
     },
     setAudioManagerInitialized: (state, action) => {
       state.audioManagerInitialized = action.payload;
-    }
+    },
+    // payload: { meetingId, sessionToken }, null to clear.
+    setAudioIntent: (state, action) => {
+      state.audioIntentMeetingId = action.payload?.meetingId ?? null;
+      state.audioIntentSessionToken = action.payload?.sessionToken ?? null;
+    },
+    setPendingMuteAssert: (state, action) => {
+      state.pendingMuteAssert = action.payload;
+      state.pendingMuteAssertEpoch += 1;
+    },
   },
 });
 
 export const {
   setAudioManagerInitialized,
+  setAudioIntent,
+  setPendingMuteAssert,
   setMutedState,
   setInputStreamId,
   setIsConnecting,

--- a/src/store/redux/slices/wide-app/client.js
+++ b/src/store/redux/slices/wide-app/client.js
@@ -102,6 +102,12 @@ const clientSlice = createSlice({
     setMeetingData: (state, action) => {
       state.meetingData = action.payload;
     },
+    // Merge variant for partial writers (e.g. user-join-screen enriching
+    // meetingData with the current user's identity)
+    // setMeetingData keeps replace semantics for full resets
+    updateMeetingData: (state, action) => {
+      Object.assign(state.meetingData, action.payload);
+    },
     setBreakoutData: (state, action) => {
       state.breakoutData = action.payload;
     },
@@ -415,6 +421,7 @@ export const {
   setInitialChatMsgsFetched,
   setSessionTerminated,
   setMeetingData,
+  updateMeetingData,
   setBreakoutData,
   setJoinUrl,
   setTransferUrl,

--- a/src/types/meetingClientSettings.ts
+++ b/src/types/meetingClientSettings.ts
@@ -655,6 +655,7 @@ export interface LiveKitAudioSettings {
   publishOptions?: TrackPublishOptions
   unpublishOnMute?: boolean
   unpublishAfterMuteMs?: number
+  useLiveKitAudioState?: boolean
 }
 
 export type SelectiveSubscriptionConfig = {


### PR DESCRIPTION
### Main changes
- [feat(livekit): LiveKit as audio state source for Last-N mute (#2515/#2536/#2607)](https://github.com/mconf/bbb-mobile-sdk/commit/b4cf09ac2178975b9cb5151d1247f7f716253c78)
  - Port pieces of PRs mconf-live/#2515, mconf-live/#2536 and mconf-live/#2607: derive **Last-N**'s who-is-unmuted set
from a new **useWhoIsUnmuted** hook (mconf-live/#2515) instead of the inline LiveKit
derivation, with **voiceUserId** coalescing for **dial-in** (mconf-live/#2536, mconf-live/#2607).
  - See details in the commit log
- [fix(audio): recover main room audio after returning from a breakout](https://github.com/mconf/bbb-mobile-sdk/commit/0e0609fe28d5ae5f29ccdd49c541c3e0e49267c9) 
  - Two issues left the main room's **mic dead and unrecoverable after
    leaving a breakout**:
    - onAudioJoin() is called with no argument from LiveKitObserver. After the
      breakout shutdown destroys the bridge, `undefined == this.bridge?.clientSessionNumber`
      is `undefined == undefined` -> true, so it dispatched setIsConnected(true) with
      no bridge/track. That stale isConnected then makes the connect effect's
      `if (isAudioConnected || isAudioConnecting) return` skip joinAudio() forever, and
      mute/unmute no-ops because _setSenderTrackEnabled early-returns on a null bridge.
      - **Fix**: require a live bridge before marking connected.
    - _mediaFactory reuses this.inputStream when MediaStream.active is truthy, but
      it seems @livekit/react-native-webrtc stubs active to always be true, so a
      dead track stopped by the breakout teardown is reused and never regenerated.
      - **Fix**: reuse the cached stream only if it still has a readyState==='live'
      audio track.
- [fix(audio): honor muteOnStart on join + mute reconciliation on voice record](https://github.com/mconf/bbb-mobile-sdk/commit/7f6514c57c1a97470d173eae497b48fb9cd40d98) 
  - Two separate issues regarding mute state reconciliation with server
state:
    - use-audio-join reads meeting.voiceProp.muteOnStart, but the meeting
  subscription transitioned to meeting.voiceSettings.muteOnStart. I.e.:
  **muteOnStart is always falsy regardless of server configs**.
    - The audio-controls server-client mute state reconciliation does not
  account for the voice record actually existing. During a reconnect
  window, voice?.* might be undefined while loading is still set to
  false. **This may cause inadvertent microphone unmutes on reconnects**.
- [feat(audio): unified mute state restore + reconciliation](https://github.com/mconf/bbb-mobile-sdk/commit/5796a9aff2efa9a8c6d767cda2a2251197b20dc9) 
  - Generalize the fatal reconnect pendingMuteRestore hack into one mechanism
covering every audio rejoin (breakout return, fatal-error reconnect, error/
permission retries), for both the LiveKit and SFU bridges. The idea is
that the user's previously selected mute state should persist across
audio session reconnects on all applicable scenarios, with the EXCEPTION of:
    - Lock settings enforcement
    - Cross-meeting/cross-session audio joins
    - Voluntary audio leaves
  - See additional details in the commit log
  
### Additional changes

- [fix(livekit): constrain camera capture to profile resolution](https://github.com/mconf/bbb-mobile-sdk/commit/88c1f6fc8bf83b6d89add74fc576101d36dbd2c9) 
  - **Note:** we'll have to observe the impact this causes on the SDK's camera quality
  - Do the same as in the web client: constrain capture at the profile resolution
via a gUM, fallback to the internal defaults if the profile does not
specify them. See commit log for issue details.
- [fix(livekit): honor selectiveSubscription.enabled + mobile-safe autoSubscribe](https://github.com/mconf/bbb-mobile-sdk/commit/245a8412f0862229dccaa62be4c091623d549af5) 
  - Enable the SelectiveSubscription component based on the selectiveSubscription
settings.yml flag to properly honor the server's config.
  - Additional touch-up: autoSubscribe is disabled (manual subscription) only
when LiveKit carries audio alone. Web can use autoSubscribe:!enabled because
it manually subscribes camera and screenshare too; mobile manages audio only
for now. autoSubscribe:false  would leave any LiveKit-carried video blank.
- [fix: stop dispatching meetingData from UserJoinScreen's render body](https://github.com/mconf/bbb-mobile-sdk/commit/2e3af6f13fa5223f78a6d11024fa1910bf711b7b) 
  - UserJoinScreen dispatches setMeetingData unconditionally in its render body
It goes unnoticed on ordinary renders, but during the exit this triggers
rendering cycles in BBBLiveKitRoom as it subscribes to setConnected etc.
tl;dr: this triggers **react exceptions** re.: **"Cannot update a component
(BBBLiveKitRoom) while rendering a different component (UserJoinScreen)"**
on session/breakout leave.
- [fix(audio): sync Redux isMuted to the requested mute state](https://github.com/mconf/bbb-mobile-sdk/commit/891768c4a78b7bc8788546d08e269b7d480d0b71) 
  - Fixes an issue with the **mute state being incorrectly restored after multiple breakout join/leave cycles**. See commit log for details.