### PR TITLE
fix(deps): pin postcss to 8.5.23 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10875,9 +10875,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10894,7 +10894,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "nanoid": "3.3.18"
+    "nanoid": "3.3.18",
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `postcss: 8.5.23` to the `overrides` block in `package.json` (same pattern already used for `nanoid`) and regenerates `package-lock.json`.
- Resolves Dependabot alerts [#123](https://github.com/mconf/bbb-mobile-sdk/security/dependabot/123), [#165](https://github.com/mconf/bbb-mobile-sdk/security/dependabot/165), [#166](https://github.com/mconf/bbb-mobile-sdk/security/dependabot/166), [#178](https://github.com/mconf/bbb-mobile-sdk/security/dependabot/178) — all postcss advisories (arbitrary `.map` file disclosure / XSS) affecting versions `< 8.5.23`.
- `postcss` is a transitive dependency only (pulled in by `@expo/metro-config` and `styled-components`, both build-time concerns) — no application source was touched.

Alerts #144 (`uuid`, via `xcode`/native prebuild tooling) and #174/#175 (`image-size`, via `metro`, no patched version published yet) were left out: fixing them would require a risky major-version bump or has no available patch yet.

## Test plan
- [x] `npm install` completed cleanly, `postcss` resolves to `8.5.23` across the tree
- [x] `npm run build` (babel `src/` → `lib/`) compiled all 339 files with no errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)