### PR TITLE
fix(livekit): follow the multi-room membership token model

### DIFF
--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -260,6 +260,12 @@ const BBBLiveKitRoom = ({ children }) => {
       // Non-final disconnect (do NOT destroy the media managers). Once the room
       // is Disconnected, the connect effect above re-fires and re-establishes the
       // room; resetting the audio flags lets it re-run joinAudio to republish mic.
+      // Tear the audio bridge down through AudioManager (rather than leaving it
+      // dangling on the singleton room until the next joinAudio call) so its
+      // stop() is tracked and awaited before a new bridge is started.
+      // No-op if there's no live bridge (e.g. audioBridge isn't 'livekit').
+      AudioManager.exitAudio();
+
       liveKitRoom.disconnect()
         .then(() => {
           dispatch(setIsConnected(false));

--- a/src/components/livekit/index.js
+++ b/src/components/livekit/index.js
@@ -17,6 +17,7 @@ import logger from '../../services/logger';
 import useMeeting from '../../graphql/hooks/useMeeting';
 import { useAudioJoin } from '../../hooks/use-audio-join';
 import useCurrentUser from '../../graphql/hooks/useCurrentUser';
+import { usePrimaryLiveKitMembership } from '../../graphql/hooks/useLiveKitMemberships';
 import {
   liveKitRoom,
   disconnectLiveKitRoom,
@@ -110,8 +111,16 @@ const BBBLiveKitRoom = ({ children }) => {
     ?.selectiveSubscription?.enabled ?? true;
   const fatalReconnectAttempts = useRef(0);
   const fatalReconnectResetTimer = useRef(null);
-  const livekitToken = currentUserData?.user_current[0]?.livekit?.livekitToken;
+  const primaryMembership = usePrimaryLiveKitMembership();
+  const livekitToken = primaryMembership?.token;
+  // Tokens are regenerated periodically: connect on token presence, not its
+  // value, so a token refresh doesn't re-run it (ie causes an uneeded reconnect)
+  const hasLiveKitToken = typeof livekitToken === 'string' && livekitToken.length > 0;
+  const initialLiveKitToken = useRef(null);
   const userId = currentUserData?.user_current[0]?.userId;
+
+  if (hasLiveKitToken && !initialLiveKitToken.current) initialLiveKitToken.current = livekitToken;
+
   const {
     cameraBridge,
     screenShareBridge,
@@ -162,6 +171,12 @@ const BBBLiveKitRoom = ({ children }) => {
 
           if (!shouldUseLiveKit || connectionState !== ConnectionState.Disconnected) return;
 
+          // Membership rows exist before their token is generated. Reject so the
+          // audio join below is skipped; the effect should re-run once the token is available.
+          if (!hasLiveKitToken) {
+            throw new Error('LiveKit membership has no token yet');
+          }
+
           return liveKitRoom.connect(url, livekitToken, connectOptions);
         })
         .then(async () => {
@@ -195,6 +210,7 @@ const BBBLiveKitRoom = ({ children }) => {
     mainRoomBlockedByBreakout,
     isAudioConnected,
     isAudioConnecting,
+    hasLiveKitToken,
     url,
     joinAudio,
   ]);
@@ -282,11 +298,12 @@ const BBBLiveKitRoom = ({ children }) => {
   if (!shouldUseLiveKit) return children;
 
   return (
+    // Pin token to the ref to avoid triggering a reconnect on token refreshes.
     <LiveKitRoom
       video={false}
       audio={false}
       connect={false}
-      token={livekitToken}
+      token={initialLiveKitToken.current}
       serverUrl={url}
       room={liveKitRoom}
       style={{ zIndex: 0, height: 'initial', width: 'initial' }}

--- a/src/graphql/hooks/useLiveKitMemberships.ts
+++ b/src/graphql/hooks/useLiveKitMemberships.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import useCurrentUser from './useCurrentUser';
+
+export interface LiveKitRoomMembership {
+  // LK room.name: the internal meeting ID that owns the room.
+  roomName: string;
+  // 'primary', 'breakout-listen', ...
+  purpose: string;
+  token: string | null;
+}
+
+const PRIMARY_PURPOSE = 'primary';
+
+const EMPTY: LiveKitRoomMembership[] = [];
+
+// Rows are written on join and only get a token once the SFU answers with it
+// so tokenless rows are filtered out rather than handed to a connect.
+const useLiveKitMemberships = (): LiveKitRoomMembership[] => {
+  const { data: currentUserData } = useCurrentUser();
+  const rooms = currentUserData?.user_current?.[0]?.livekitRooms;
+
+  return useMemo(() => {
+    if (!rooms) return EMPTY;
+
+    const active = rooms.filter(
+      (room: LiveKitRoomMembership) => typeof room.token === 'string' && room.token.length > 0,
+    );
+
+    return active.length > 0 ? active : EMPTY;
+  }, [rooms]);
+};
+
+// Unordered array relationship - pick by purpose, never by index.
+export const usePrimaryLiveKitMembership = (): LiveKitRoomMembership | undefined => {
+  const memberships = useLiveKitMemberships();
+
+  return useMemo(
+    () => memberships.find((membership) => membership.purpose === PRIMARY_PURPOSE),
+    [memberships],
+  );
+};
+
+export default usePrimaryLiveKitMembership;

--- a/src/graphql/queries/useCurrentUserSubscription.js
+++ b/src/graphql/queries/useCurrentUserSubscription.js
@@ -75,8 +75,10 @@ const USER_CURRENT_SUBSCRIPTION = gql`
       sessionCurrent {
         enforceLayout
       }
-      livekit {
-        livekitToken
+      livekitRooms {
+        roomName
+        purpose
+        token
       }
     }
   }

--- a/src/services/webrtc/audio-manager.js
+++ b/src/services/webrtc/audio-manager.js
@@ -48,6 +48,9 @@ class AudioManager {
     this.iceServers = null;
     this.isListenOnly = false;
     this._livekitBridge = null;
+    // Tracks a bridge's in-flight stop() so a new bridge is never started
+    // while the previous one is still tearing down (see _joinAudio/exitAudio).
+    this._pendingStop = null;
   }
 
   get bridge() {
@@ -382,14 +385,22 @@ class AudioManager {
     }
   }
 
-  _joinAudio(callOptions = {}) {
+  async _joinAudio(callOptions = {}) {
     if (!this.initialized) throw new TypeError('Audio manager is not ready');
 
     // There's a stale bridge here. Tear it down and start again.
     if (this.bridge) {
       this._deattachProgressListeners(this.bridge);
-      this.bridge.stop();
+      this._pendingStop = this.bridge.stop();
       this.bridge = null;
+    }
+
+    // Never start a new bridge while the previous one is still mid-teardown -
+    // both would concurrently drive the same singleton LiveKit room/participant
+    // (setMicrophoneEnabled/publish/unpublish), which is unsafe.
+    if (this._pendingStop) {
+      await this._pendingStop;
+      this._pendingStop = null;
     }
 
     this.bridge = this._initializeBridge(callOptions);
@@ -433,7 +444,7 @@ class AudioManager {
     }
 
     store.dispatch(setIsHangingUp(true));
-    this.bridge.stop();
+    this._pendingStop = this.bridge.stop();
     this.bridge = null;
   }
 


### PR DESCRIPTION
> [!NOTE] 
> This is **not backwards compatible** with mconf-live <= 3.1.0-38 nor BBB < 4.0.0-rc.1

BBB PR 25638 replaced user_livekit with user_livekit_room: v_user_current's
`livekit` object relationship became the `livekitRooms` array, and
`livekitToken` became `token` alongside `roomName`/`purpose`.

Take the token from the membership whose purpose is 'primary'.
Membership rows are now written on join and only get a token once
BBB gens it (asynchronously), so the connect act is still conditional to
whether the token exists.

BBB also regens tokens at 75% of their TTL. This commits has some checks
in place to guarantee that token refreshes won't cause uneeded
reconnects on working session; only new connects or valid re-connects
should be up the new token.

Secondary-purpose rooms and breakout listen-in are not handled here.