### PR TITLE
feat: set Nunito Sans as the app's default font

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,8 @@ import { Provider } from 'react-redux';
 import { NavigationContainer, DefaultTheme, NavigationIndependentTree } from '@react-navigation/native';
 import { OrientationLocker, PORTRAIT } from 'react-native-orientation-locker';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
+import { useFonts } from 'expo-font';
+import { PaperProvider } from 'react-native-paper';
 import { store } from './src/store/redux/store';
 // components
 import InCallManagerController from './src/app-content/in-call-manager';
@@ -17,6 +19,8 @@ import { injectStore as injectStoreAM } from './src/services/webrtc/audio-manage
 // constants
 import './src/utils/locales/i18n';
 import Colors from './src/constants/colors';
+import { FONT_ASSETS, navigationFonts } from './src/constants/fonts';
+import paperTheme from './src/constants/paper-theme';
 
 const injectStore = () => {
   injectStoreVM(store);
@@ -30,6 +34,7 @@ const MyTheme = {
     ...DefaultTheme.colors,
     background: Colors.blueBackgroundColor
   },
+  fonts: navigationFonts,
 };
 
 const leaveSessionFactory = (callback = () => { }) => {
@@ -46,27 +51,36 @@ const App = (props) => {
     || defaultJoinURL();
   const _onLeaveSession = leaveSessionFactory(onLeaveSession);
 
+  // Nunito Sans is the app's default typeface; hold rendering until the faces
+  // are registered so no screen flashes the system font. On failure, render
+  // anyway with the platform fallback.
+  const [fontsLoaded, fontsError] = useFonts(FONT_ASSETS);
+
   useEffect(() => {
     injectStore();
   }, []);
 
+  if (!fontsLoaded && !fontsError) return null;
+
   return (
     <KeyboardProvider>
-      <Provider store={store}>
-        <NavigationIndependentTree>
-          <NavigationContainer theme={MyTheme}>
-            <OrientationLocker orientation={PORTRAIT} />
-            <NavigatorHandler
-              {...props}
-              joinURL={_joinURL}
-              onLeaveSession={_onLeaveSession}
-            />
-            <AppStatusBar />
-            <InCallManagerController />
-            <LocalesController defaultLanguage={defaultLanguage} />
-          </NavigationContainer>
-        </NavigationIndependentTree>
-      </Provider>
+      <PaperProvider theme={paperTheme}>
+        <Provider store={store}>
+          <NavigationIndependentTree>
+            <NavigationContainer theme={MyTheme}>
+              <OrientationLocker orientation={PORTRAIT} />
+              <NavigatorHandler
+                {...props}
+                joinURL={_joinURL}
+                onLeaveSession={_onLeaveSession}
+              />
+              <AppStatusBar />
+              <InCallManagerController />
+              <LocalesController defaultLanguage={defaultLanguage} />
+            </NavigationContainer>
+          </NavigationIndependentTree>
+        </Provider>
+      </PaperProvider>
     </KeyboardProvider>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@browser-bunyan/server-stream": "1.8.0",
         "@config-plugins/react-native-callkeep": "12.0.0",
         "@config-plugins/react-native-webrtc": "13.0.0",
+        "@expo-google-fonts/nunito-sans": "0.4.2",
         "@expo/vector-icons": "15.1.1",
         "@gorhom/bottom-sheet": "5.2.14",
         "@livekit/react-native": "2.11.0",
@@ -1913,6 +1914,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@expo-google-fonts/nunito-sans": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/nunito-sans/-/nunito-sans-0.4.2.tgz",
+      "integrity": "sha512-e4+jUhgXNC6Zahf3MQwiiUimjWPp/Noe5v7CxBDbvXED+E7p7/egDaXKTbLwSBJku/mP3N+vNdJwk5xKAjkQmg==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "54.0.26",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@browser-bunyan/server-stream": "1.8.0",
     "@config-plugins/react-native-callkeep": "12.0.0",
     "@config-plugins/react-native-webrtc": "13.0.0",
+    "@expo-google-fonts/nunito-sans": "0.4.2",
     "@expo/vector-icons": "15.1.1",
     "@gorhom/bottom-sheet": "5.2.14",
     "@livekit/react-native": "2.11.0",

--- a/src/components/actions-bar/audio-button/styles.js
+++ b/src/components/actions-bar/audio-button/styles.js
@@ -3,6 +3,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { TouchableRipple } from 'react-native-paper';
 import { View } from 'react-native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const ContainerPressable = styled(TouchableRipple)`
   display: flex;
@@ -29,7 +30,7 @@ const HeadphoneIconContainer = ({ isActive }) => (
   </View>
 );
 
-const HeadphoneText = styled.Text`
+const HeadphoneText = styled(Text)`
   font-size: 16px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/components/actions-bar/audio-device-selector-control/audio-device-selector-modal/styles.js
+++ b/src/components/actions-bar/audio-device-selector-control/audio-device-selector-modal/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { ActivityIndicator, Button, IconButton } from 'react-native-paper';
 import Colors from '../../../../constants/colors';
+import { Text } from '../../../typography';
 
 const ButtonCreate = styled(Button)`
 `;
@@ -25,7 +26,7 @@ const ButtonContainer = ({ loading, children }) => {
   );
 };
 
-const DeviceSelectorTitle = styled.Text`
+const DeviceSelectorTitle = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
@@ -41,7 +42,7 @@ const Container = styled.View`
   border-radius: 12px;
 `;
 
-const MissingPermission = styled.Text`
+const MissingPermission = styled(Text)`
   font-size: 14px;
   font-weight: 500;
   text-align: center;

--- a/src/components/actions-bar/audio-device-selector-control/styles.js
+++ b/src/components/actions-bar/audio-device-selector-control/styles.js
@@ -3,6 +3,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { TouchableRipple } from 'react-native-paper';
 import { View } from 'react-native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const ContainerPressable = styled(TouchableRipple)`
   display: flex;
@@ -37,7 +38,7 @@ const AudioIconContainer = () => (
   </View>
 );
 
-const AudioText = styled.Text`
+const AudioText = styled(Text)`
   font-size: 16px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/components/actions-bar/debug-control/styles.js
+++ b/src/components/actions-bar/debug-control/styles.js
@@ -3,6 +3,7 @@ import { Switch } from 'react-native-paper';
 import { FontAwesome } from '@expo/vector-icons';
 import { View } from 'react-native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const DebugContainer = styled.View`
   display: flex;
@@ -29,7 +30,7 @@ const DebugIconContainer = () => (
   </View>
 );
 
-const DebugText = styled.Text`
+const DebugText = styled(Text)`
   font-size: 16px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/components/actions-bar/screenshare-button/styles.js
+++ b/src/components/actions-bar/screenshare-button/styles.js
@@ -3,6 +3,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { TouchableRipple } from 'react-native-paper';
 import { View } from 'react-native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const ContainerPressable = styled(TouchableRipple)`
   display: flex;
@@ -30,7 +31,7 @@ const ScreenshareIconContainer = () => (
   </View>
 );
 
-const ScreenshareText = styled.Text`
+const ScreenshareText = styled(Text)`
   font-size: 16px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/components/audio-player/audio-slider/styles.js
+++ b/src/components/audio-player/audio-slider/styles.js
@@ -2,15 +2,16 @@ import styled from 'styled-components/native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { TouchableRipple } from 'react-native-paper';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
-const FileNameText = styled.Text`
+const FileNameText = styled(Text)`
   font-size: 14px;
   font-weight: 400;
   color: ${Colors.lightGray400};
   height: 25px;
 `;
 
-const DurationText = styled.Text`
+const DurationText = styled(Text)`
   font-size: 10px;
   font-weight: 400;
   color: #B1B3B3;

--- a/src/components/bar-notification/styles.js
+++ b/src/components/bar-notification/styles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+import { Text as BaseText } from '../typography';
 
 const IndexContainer = styled.View`
   ${(props) => props.index === 1 && `
@@ -25,7 +26,7 @@ const TextContainer = styled.View`
   padding: 8px 16px;
 `;
 
-const Text = styled.Text`
+const Text = styled(BaseText)`
   font-size: 12px;
   color: white;
 `;

--- a/src/components/buttons/primary-button/styles.js
+++ b/src/components/buttons/primary-button/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const LoadingContainer = styled.View`
   display: flex;
@@ -52,7 +53,7 @@ const ButtonInnerContainer = styled.Pressable`
 
 // TODO: Added pollOptions since the old version had slightly different styles for that variant
 // when the refactor for styled components is being implemented, consider homogenizing these styles
-const ButtonText = styled.Text`
+const ButtonText = styled(Text)`
   color: ${({ variant, mode, disabled }) => {
     if (disabled) return Colors.white;
     if (mode === 'text') return Colors.white;

--- a/src/components/chat/bottom-sheet-chat/chat-message/system-message/styles.js
+++ b/src/components/chat/bottom-sheet-chat/chat-message/system-message/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../../../constants/colors';
+import { Text } from '../../../../typography';
 
 const Card = styled.View`
   padding: 8px;
@@ -14,7 +15,7 @@ const ServerContainer = styled.View`
   gap: 4px;
 `;
 
-const ServerMsg = styled.Text`
+const ServerMsg = styled(Text)`
   font-weight: 500;
   color: ${Colors.lightGray400};
 `;

--- a/src/components/chat/bottom-sheet-chat/chat-message/user-message/styles.js
+++ b/src/components/chat/bottom-sheet-chat/chat-message/user-message/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import userAvatar from '../../../../user-avatar';
 import Colors from '../../../../../constants/colors';
+import { Text } from '../../../../typography';
 
 const Card = styled.View`
   padding: 8px;
@@ -18,18 +19,18 @@ const MessageTopContainer = styled.View`
   flex-direction: row;
 `;
 
-const MessageAuthor = styled.Text`
+const MessageAuthor = styled(Text)`
   color: ${Colors.lightGray400};
   font-weight: 500;
 `;
 
-const MessageTimestamp = styled.Text`
+const MessageTimestamp = styled(Text)`
   color: ${Colors.lightGray200};
   padding-left: 8px;
   font-style: italic;
 `;
 
-const MessageContent = styled.Text`
+const MessageContent = styled(Text)`
   color: ${Colors.lightGray300};
 `;
 

--- a/src/components/chat/bottom-sheet-chat/styles.js
+++ b/src/components/chat/bottom-sheet-chat/styles.js
@@ -1,12 +1,13 @@
 import styled from 'styled-components/native';
 import { StyleSheet } from 'react-native';
 import textInput from '../../text-input';
+import { Text } from '../../typography';
 
 const FlatList = styled.FlatList`
   width: 100%;
 `;
 
-const NoMessageText = styled.Text`
+const NoMessageText = styled(Text)`
   font-size: 24px;
   text-align: center;
   padding: 8px;

--- a/src/components/chat/chat-popup/chat-popout-item/styles.js
+++ b/src/components/chat/chat-popup/chat-popout-item/styles.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components/native';
 import { Entypo } from '@expo/vector-icons';
 import Pressable from '../../../pressable';
+import { Text } from '../../../typography';
 
 const ContainerPressable = styled(Pressable).attrs(() => ({
   pressStyle: {
@@ -33,14 +34,14 @@ const TextContainer = styled.View`
   padding: 8px;
 `;
 
-const UserNameText = styled.Text`
+const UserNameText = styled(Text)`
   font-size: 12px;
   color: white;
   font-weight: 700;
   vertical-align: middle;
 `;
 
-const UserMessage = styled.Text`
+const UserMessage = styled(Text)`
   font-size: 12px;
   color: white;
 `;

--- a/src/components/custom-drawer/drawer-navigator/index.js
+++ b/src/components/custom-drawer/drawer-navigator/index.js
@@ -27,6 +27,7 @@ import ChatPopupList from '../../chat/chat-popup';
 import RecordingIndicator from '../../record/record-indicator';
 import CustomDrawer from '../index';
 import Styled from './styles';
+import Fonts from '../../../constants/fonts';
 
 // react-navigation v7 removed the `unmountOnBlur` screen option; this replaces it by
 // rendering null while unfocused. Wrapped components are hoisted to module scope so their
@@ -282,7 +283,7 @@ const DrawerNavigator = ({
           options={{
             title: t('app.notes.title'),
             drawerLabelStyle: {
-              fontWeight: '400', fontSize: 16, paddingLeft: 12
+              fontFamily: Fonts.regular, fontWeight: '400', fontSize: 16, paddingLeft: 12
             },
             drawerIcon: (config) => (
               <Styled.IconMaterial name="notes" size={24} color={config.color} />
@@ -336,7 +337,7 @@ const DrawerNavigator = ({
                 );
               },
               drawerLabelStyle: {
-                fontWeight: '400', fontSize: 16, paddingLeft: 12
+                fontFamily: Fonts.regular, fontWeight: '400', fontSize: 16, paddingLeft: 12
               },
               drawerIcon: (config) => (
                 <Styled.IconMaterial name="timer" size={24} color={config.color} />

--- a/src/components/custom-drawer/drawer-navigator/styles.js
+++ b/src/components/custom-drawer/drawer-navigator/styles.js
@@ -2,7 +2,9 @@ import styled from 'styled-components/native';
 import Icon from '@expo/vector-icons/MaterialIcons';
 import iconButton from '../../icon-button';
 import Colors from '../../../constants/colors';
+import Fonts from '../../../constants/fonts';
 import Tag from '../../tag';
+import { Text } from '../../typography';
 
 const DrawerIcon = styled(iconButton)`
   position: absolute;
@@ -30,7 +32,7 @@ const HeaderTitleContainer = styled.View`
   gap: 10px;
 `;
 
-const HeaderTitleText = styled.Text`
+const HeaderTitleText = styled(Text)`
   color: ${Colors.white};
   text-align: center;
   font-size: 20px;
@@ -69,6 +71,7 @@ const ScreenOptions = {
     textAlignVertical: 'center',
     paddingLeft: 12,
     fontSize: 16,
+    fontFamily: Fonts.regular,
     fontWeight: '400',
     lineHeight: 18,
   },

--- a/src/components/custom-drawer/styles.js
+++ b/src/components/custom-drawer/styles.js
@@ -5,7 +5,9 @@ import Icon from '@expo/vector-icons/MaterialIcons';
 import Tag from '../tag';
 import userAvatar from '../user-avatar';
 import Colors from '../../constants/colors';
+import Fonts from '../../constants/fonts';
 import Pressable from '../pressable';
+import { Text } from '../typography';
 
 const ViewContainer = styled.View`
   flex: 1;
@@ -26,7 +28,7 @@ const UserAvatar = styled(userAvatar)`
   margin-bottom: 10px;
 `;
 
-const NameUserAvatar = styled.Text`
+const NameUserAvatar = styled(Text)`
   color: ${Colors.white};
   font-size: 18px;
   padding-left: 20px;
@@ -81,6 +83,7 @@ const TextButtonLabel = {
   paddingRight: 20,
   color: Colors.lightGray400,
   fontSize: 16,
+  fontFamily: Fonts.regular,
   fontWeight: 400,
   textAlign: 'left',
 };
@@ -90,6 +93,7 @@ const TextButtonActive = {
   paddingRight: 20,
   color: Colors.white,
   fontSize: 16,
+  fontFamily: Fonts.regular,
   fontWeight: 400,
   textAlign: 'left',
 };

--- a/src/components/debug-window/styles.js
+++ b/src/components/debug-window/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../typography';
 
 const ContainerInside = styled.View`
   background-color: #000000aa;
@@ -19,12 +20,12 @@ const TextContainer = styled.View`
   padding: 8px;
 `;
 
-const PayloadMessage = styled.Text`
+const PayloadMessage = styled(Text)`
   font-size: 10px;
   color: ${Colors.lightGray100};
 `;
 
-const TypeMessage = styled.Text`
+const TypeMessage = styled(Text)`
   font-size: 12px;
   font-weight: 800;
   color: white;

--- a/src/components/external-video/styles.js
+++ b/src/components/external-video/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text as BaseText } from '../typography';
 
 const Container = styled.View`
   display: flex;
@@ -17,7 +18,7 @@ const Card = styled.View`
   justify-content: center;
 `;
 
-const Text = styled.Text`
+const Text = styled(BaseText)`
   color: ${Colors.white};
   font-size: 24px;
   font-weight: 600;

--- a/src/components/interactions/reactions-bar/styles.js
+++ b/src/components/interactions/reactions-bar/styles.js
@@ -3,6 +3,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import Pressable from '../../pressable';
 import Colors from '../../../constants/colors';
 import LayoutConstants from '../../../constants/layout';
+import { Text } from '../../typography';
 
 const BOTTOM_OFFSET = LayoutConstants.ACTIONS_BAR_COLLAPSED_HEIGHT + 10;
 
@@ -39,7 +40,7 @@ const ReactionButton = styled(Pressable).attrs(() => ({
   `}
 `;
 
-const Reaction = styled.Text`
+const Reaction = styled(Text)`
   font-size: 24px;
   line-height: 30px;
 `;

--- a/src/components/interactions/reactions-controls/styles.js
+++ b/src/components/interactions/reactions-controls/styles.js
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
-import { Text } from 'react-native';
 import IconButtonComponent from '../../icon-button';
 import ReactionsIcon from './reactions-icon';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const ReactionsButton = ({
   currentUserReaction, isOpen, accessibilityLabel, onPress

--- a/src/components/modal/not-implemented/styles.js
+++ b/src/components/modal/not-implemented/styles.js
@@ -1,6 +1,8 @@
 import { Button } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import Fonts from '../../../constants/fonts';
+import { Text } from '../../typography';
 
 const Container = styled.View`
   display: flex;
@@ -12,21 +14,21 @@ const Container = styled.View`
   border-radius: 12px;
 `;
 
-const TitleModal = styled.Text`
+const TitleModal = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
   text-align: center;
 `;
 
-const TitleDesc = styled.Text`
+const TitleDesc = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray300};
   text-align: center;
 `;
 
-const RoomName = styled.Text`
+const RoomName = styled(Text)`
   font-size: 16px;
   font-weight: 600;
   color: ${Colors.lightGray300};
@@ -46,7 +48,7 @@ const OkButton = ({
       textColor={Colors.white}
       labelStyle={{
         fontSize: 18,
-        fontWeight: 500,
+        fontFamily: Fonts.medium,
       }}
     >
       {children}

--- a/src/components/modal/styles.js
+++ b/src/components/modal/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../typography';
 
 const Container = styled.View`
   display: flex;
@@ -11,13 +12,13 @@ const Container = styled.View`
   border-radius: 12px;
 `;
 
-const TitleModal = styled.Text`
+const TitleModal = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
 `;
 
-const TitleDesc = styled.Text`
+const TitleDesc = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray300};

--- a/src/components/record/modals/record-controls-modal/styles.js
+++ b/src/components/record/modals/record-controls-modal/styles.js
@@ -1,7 +1,11 @@
 import styled from 'styled-components/native';
-import { View, Text, TouchableOpacity } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+} from 'react-native';
 import Icon from '@expo/vector-icons/MaterialIcons';
 import Colors from '../../../../constants/colors';
+import { Text } from '../../../typography';
 
 const ModalContainer = styled(View)`
   justify-content: center;

--- a/src/components/record/modals/record-status-modal/styles.js
+++ b/src/components/record/modals/record-status-modal/styles.js
@@ -1,7 +1,10 @@
 import styled from 'styled-components/native';
-import { View, Text } from 'react-native';
+import {
+  View,
+} from 'react-native';
 import Icon from '@expo/vector-icons/MaterialIcons';
 import Colors from '../../../../constants/colors';
+import { Text } from '../../../typography';
 
 const ModalContainer = styled(View)`
   justify-content: center;

--- a/src/components/socket-connection/index.js
+++ b/src/components/socket-connection/index.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Text, View } from 'react-native';
+import {
+  View,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import Settings from '../../../settings.json';
 // collections
@@ -65,6 +67,7 @@ import {
   join,
 } from '../../store/redux/slices/wide-app/client';
 import usePrevious from '../../hooks/use-previous';
+import { Text } from '../typography';
 
 // TODO BAD - decouple, move elsewhere - everything from here to getMeetingData
 let GLOBAL_WS = null;

--- a/src/components/tag/styles.js
+++ b/src/components/tag/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text as BaseText } from '../typography';
 
 const Container = styled.View`
   padding: 4px 8px;
@@ -7,7 +8,7 @@ const Container = styled.View`
   background-color: ${Colors.orange};
 `;
 
-const Text = styled.Text`
+const Text = styled(BaseText)`
   color: ${Colors.white};
   font-size: 14px;
   font-weight: 800;

--- a/src/components/talking-indicator/styles.js
+++ b/src/components/talking-indicator/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components/native';
 import { TouchableRipple } from 'react-native-paper';
 import { MaterialIcons } from '@expo/vector-icons';
 import Colors from '../../constants/colors';
+import { Text as BaseText } from '../typography';
 
 const Container = styled.View`
   display: flex;
@@ -24,7 +25,7 @@ const TextContainer = styled.View`
   align-self: flex-end;
 `;
 
-const Text = styled.Text`
+const Text = styled(BaseText)`
   color: ${Colors.white};
   font-size: 14px;
   font-weight: 600;

--- a/src/components/timer/timerIndicator/styles.js
+++ b/src/components/timer/timerIndicator/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components/native';
 import { View } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import Colors from '../../../constants/colors';
+import { Text as BaseText } from '../../typography';
 
 const Container = styled.View`
   display: flex;
@@ -30,7 +31,7 @@ const TextContainer = ({ children, running }) => (
   </View>
 );
 
-const Text = styled.Text`
+const Text = styled(BaseText)`
   color: ${({ running }) => (running ? Colors.white : Colors.blue)};
   font-size: 14px;
   font-weight: 600;

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -1,0 +1,46 @@
+import { forwardRef } from 'react';
+import {
+  StyleSheet,
+  Text as RNText,
+  TextInput as RNTextInput,
+} from 'react-native';
+import { fontFamilyFor, isAppFontFamily } from '../../constants/fonts';
+
+// Resolves a RN text style to the app's default typeface.
+//
+// - No `fontFamily`: picks the Nunito Sans face matching `fontWeight`/`fontStyle`
+//   and drops those two props (a loaded expo-font face already *is* a weight;
+//   leaving `fontWeight` on would make Android synthesize a fake bold on top).
+// - One of our faces as `fontFamily`: same cleanup, keeps the chosen face.
+// - Any other `fontFamily` (icon fonts, monospace, ...): returned untouched.
+export const withDefaultFont = (style) => {
+  const flat = StyleSheet.flatten(style) || {};
+  const {
+    fontFamily,
+    fontWeight,
+    fontStyle,
+    ...rest
+  } = flat;
+
+  if (fontFamily && !isAppFontFamily(fontFamily)) return flat;
+
+  return {
+    ...rest,
+    fontFamily: fontFamily || fontFamilyFor(fontWeight, fontStyle),
+  };
+};
+
+// Drop-in replacements for react-native's Text/TextInput. `font-weight` and
+// `font-style` keep working in styled-components; they are translated to the
+// right Nunito Sans face at render time.
+export const Text = forwardRef(({ style, ...props }, ref) => (
+  <RNText ref={ref} {...props} style={withDefaultFont(style)} />
+));
+Text.displayName = 'Text';
+
+export const TextInput = forwardRef(({ style, ...props }, ref) => (
+  <RNTextInput ref={ref} {...props} style={withDefaultFont(style)} />
+));
+TextInput.displayName = 'TextInput';
+
+export default Text;

--- a/src/components/user-avatar/styles.js
+++ b/src/components/user-avatar/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
 import IconButtonComponent from '../icon-button';
+import { Text } from '../typography';
 
 const Background = styled.View`
   width: 52px;
@@ -85,7 +86,7 @@ const ImageContainer = styled.View`
   `}
 `;
 
-const UserName = styled.Text`
+const UserName = styled(Text)`
   color: ${Colors.white};
   font-size: 18px;
 

--- a/src/components/video/video-container/styles.js
+++ b/src/components/video/video-container/styles.js
@@ -4,6 +4,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import IconButtonComponent from '../../icon-button';
 import Colors from '../../../constants/colors';
 import Pressable from '../../pressable';
+import { Text } from '../../typography';
 
 const ContainerPressable = styled(Pressable).attrs(() => ({
   pressStyle: {
@@ -53,7 +54,7 @@ const NameLabelContainer = styled.View`
   margin: 5px;
   border-radius: 4px;
 `;
-const NameLabel = styled.Text`
+const NameLabel = styled(Text)`
   color: ${Colors.white};
 `;
 

--- a/src/components/video/video-grid/styles.js
+++ b/src/components/video/video-grid/styles.js
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import VideoContainer from '../video-container';
 import contentArea from '../../content-area';
 import Colors from '../../../constants/colors';
+import { Text } from '../../typography';
 
 const VideoListItem = styled(VideoContainer)`
   width: 100%;
@@ -131,14 +132,14 @@ const ContainerViewItem = styled.View`
   `}
 `;
 
-const SessionAloneTitle = styled.Text`
+const SessionAloneTitle = styled(Text)`
   color: white;
   font-weight: 600;
   font-size: 24px;
   text-align: center;
 `;
 
-const SessionAloneDesc = styled.Text`
+const SessionAloneDesc = styled(Text)`
   color: white;
   font-weight: 400;
   font-size: 18px;
@@ -170,14 +171,14 @@ const ContainerTextSessionAlone = styled.View`
 
 const NoPollsImage = styled.Image``;
 
-const NoPollsLabelTitle = styled.Text`
+const NoPollsLabelTitle = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   text-align: center;
   font-weight: 500;
 `;
 
-const NoPollsLabelSubtitle = styled.Text`
+const NoPollsLabelSubtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;

--- a/src/constants/fonts.js
+++ b/src/constants/fonts.js
@@ -1,0 +1,85 @@
+import * as NunitoSans from '@expo-google-fonts/nunito-sans';
+
+// Nunito Sans is the app's default typeface (Figma: App 2025, node 7751-5408).
+//
+// React Native does not resolve `fontWeight`/`fontStyle` against fonts loaded
+// with expo-font: every weight is a separate `fontFamily`. The tables below are
+// the single source of truth for which faces are bundled and how a CSS weight
+// maps onto them. Use the `Text`/`TextInput` components from
+// `components/typography` (they do the mapping automatically) or the `Fonts`
+// constants when you have to pass a raw style object (e.g. navigator options).
+
+// Faces registered with expo-font. Keys are the `fontFamily` names.
+export const FONT_ASSETS = {
+  NunitoSans_300Light: NunitoSans.NunitoSans_300Light,
+  NunitoSans_400Regular: NunitoSans.NunitoSans_400Regular,
+  NunitoSans_500Medium: NunitoSans.NunitoSans_500Medium,
+  NunitoSans_600SemiBold: NunitoSans.NunitoSans_600SemiBold,
+  NunitoSans_700Bold: NunitoSans.NunitoSans_700Bold,
+  NunitoSans_800ExtraBold: NunitoSans.NunitoSans_800ExtraBold,
+  NunitoSans_400Regular_Italic: NunitoSans.NunitoSans_400Regular_Italic,
+  NunitoSans_600SemiBold_Italic: NunitoSans.NunitoSans_600SemiBold_Italic,
+  NunitoSans_700Bold_Italic: NunitoSans.NunitoSans_700Bold_Italic,
+};
+
+const UPRIGHT_BY_WEIGHT = {
+  300: 'NunitoSans_300Light',
+  400: 'NunitoSans_400Regular',
+  500: 'NunitoSans_500Medium',
+  600: 'NunitoSans_600SemiBold',
+  700: 'NunitoSans_700Bold',
+  800: 'NunitoSans_800ExtraBold',
+};
+
+const ITALIC_BY_WEIGHT = {
+  400: 'NunitoSans_400Regular_Italic',
+  600: 'NunitoSans_600SemiBold_Italic',
+  700: 'NunitoSans_700Bold_Italic',
+};
+
+const Fonts = {
+  light: UPRIGHT_BY_WEIGHT[300],
+  regular: UPRIGHT_BY_WEIGHT[400],
+  medium: UPRIGHT_BY_WEIGHT[500],
+  semiBold: UPRIGHT_BY_WEIGHT[600],
+  bold: UPRIGHT_BY_WEIGHT[700],
+  extraBold: UPRIGHT_BY_WEIGHT[800],
+  italic: ITALIC_BY_WEIGHT[400],
+  semiBoldItalic: ITALIC_BY_WEIGHT[600],
+  boldItalic: ITALIC_BY_WEIGHT[700],
+};
+
+// Accepts every value RN accepts for `fontWeight` ('normal', 'bold', '600', 600).
+export const normalizeFontWeight = (weight) => {
+  if (weight === undefined || weight === null || weight === 'normal') return 400;
+  if (weight === 'bold') return 700;
+  const numeric = Number(weight);
+  return Number.isNaN(numeric) ? 400 : numeric;
+};
+
+const closestWeight = (table, target) => Object.keys(table)
+  .map(Number)
+  .reduce((best, weight) => (
+    Math.abs(weight - target) < Math.abs(best - target) ? weight : best
+  ));
+
+// Returns the bundled Nunito Sans face closest to a CSS weight/style pair.
+export const fontFamilyFor = (fontWeight, fontStyle) => {
+  const table = fontStyle === 'italic' ? ITALIC_BY_WEIGHT : UPRIGHT_BY_WEIGHT;
+  return table[closestWeight(table, normalizeFontWeight(fontWeight))];
+};
+
+// react-navigation v7 themes carry a `fonts` map (header titles, drawer labels,
+// tab labels...). Spread this into the NavigationContainer theme.
+export const navigationFonts = {
+  regular: { fontFamily: Fonts.regular },
+  medium: { fontFamily: Fonts.medium },
+  bold: { fontFamily: Fonts.bold },
+  heavy: { fontFamily: Fonts.extraBold },
+};
+
+export const isAppFontFamily = (fontFamily) => (
+  Object.prototype.hasOwnProperty.call(FONT_ASSETS, fontFamily)
+);
+
+export default Fonts;

--- a/src/constants/paper-theme.js
+++ b/src/constants/paper-theme.js
@@ -1,0 +1,24 @@
+import { MD3LightTheme, configureFonts } from 'react-native-paper';
+import { fontFamilyFor } from './fonts';
+
+// react-native-paper components (Button, TextInput, Menu, ...) render their own
+// Text and only pick up fonts through the theme. This keeps paper's default
+// (light) palette — the app never relied on a Provider before, so colors must
+// not change — and swaps every type variant to the matching Nunito Sans face.
+const fontConfig = Object.fromEntries(
+  Object.entries(MD3LightTheme.fonts).map(([variant, font]) => [
+    variant,
+    {
+      ...font,
+      fontFamily: fontFamilyFor(font.fontWeight, font.fontStyle),
+      fontWeight: undefined,
+    },
+  ]),
+);
+
+const paperTheme = {
+  ...MD3LightTheme,
+  fonts: configureFonts({ config: fontConfig }),
+};
+
+export default paperTheme;

--- a/src/screens/breakout-room-screen/breakout-invite-modal/styles.js
+++ b/src/screens/breakout-room-screen/breakout-invite-modal/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const Container = styled.View`
   display: flex;
@@ -16,19 +17,19 @@ const Container = styled.View`
   `}
 `;
 
-const TitleModal = styled.Text`
+const TitleModal = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
 `;
 
-const TitleDesc = styled.Text`
+const TitleDesc = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray300};
 `;
 
-const RoomName = styled.Text`
+const RoomName = styled(Text)`
   font-size: 16px;
   font-weight: 600;
   color: ${Colors.lightGray300};

--- a/src/screens/breakout-room-screen/styles.js
+++ b/src/screens/breakout-room-screen/styles.js
@@ -3,6 +3,7 @@ import { Divider } from 'react-native-paper';
 import Colors from '../../constants/colors';
 import UserAvatar from '../../components/user-avatar';
 import ContentLoader, { Rect } from 'react-content-loader/native';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   ${({ orientation }) => orientation === 'LANDSCAPE'
@@ -39,14 +40,14 @@ const Card = styled.View`
   flex-direction: column;
 `;
 
-const ShortName = styled.Text`
+const ShortName = styled(Text)`
   color: black;
   font-size: 21px;
   font-weight: 500;
   padding: 0 0 6px 0;
 `;
 
-const ParticipantsCount = styled.Text`
+const ParticipantsCount = styled(Text)`
   color: ${Colors.lightGray300};
   font-size: 12px;
 `;
@@ -59,7 +60,7 @@ const ParticipantsContainerExpandable = styled.View`
   margin-left: 6px;
 `;
 
-const UserNameText = styled.Text`
+const UserNameText = styled(Text)`
   color: ${Colors.lightGray300};
   font-size: 16px;
   padding-left: 4px;
@@ -74,13 +75,13 @@ const FlatList = styled.FlatList`
   height: 78%;
 `;
 
-const TitleText = styled.Text`
+const TitleText = styled(Text)`
   color: white;
   font-size: 18px;
   text-align: center;
 `;
 
-const NoBreakoutsLabelTitle = styled.Text`
+const NoBreakoutsLabelTitle = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   text-align: center;
@@ -88,14 +89,14 @@ const NoBreakoutsLabelTitle = styled.Text`
   font-weight: 500;
 `;
 
-const NoBreakoutsLabelSubtitle = styled.Text`
+const NoBreakoutsLabelSubtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;
   padding: 24px;
 `;
 
-const BreakoutRoomDurationLabel = styled.Text`
+const BreakoutRoomDurationLabel = styled(Text)`
   color: ${Colors.lightGray300};
   font-size: 12px;
   text-align: center;
@@ -103,7 +104,7 @@ const BreakoutRoomDurationLabel = styled.Text`
   padding: 0 0 12px 0;
 `;
 
-const NumberTimerLabel = styled.Text`
+const NumberTimerLabel = styled(Text)`
   color: ${Colors.lightGray400};
   font-size: 24px;
   text-align: center;

--- a/src/screens/end-session-screen/styles.js
+++ b/src/screens/end-session-screen/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { Button } from 'react-native-paper';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,7 +13,7 @@ const ContainerView = styled.View`
   gap: 24px;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   text-align: center;
@@ -24,7 +25,7 @@ const Image = styled.Image`
   height: 150px;
 `;
 
-const Subtitle = styled.Text`
+const Subtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;

--- a/src/screens/feedback-screen/email-feedback-screen/styles.js
+++ b/src/screens/feedback-screen/email-feedback-screen/styles.js
@@ -1,6 +1,7 @@
 import { TextInput, Button } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,14 +13,14 @@ const ContainerView = styled.View`
   padding: 16px;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 500;
   text-align: center;
   color: ${Colors.white};
 `;
 
-const Subtitle = styled.Text`
+const Subtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;

--- a/src/screens/feedback-screen/pip-view/styles.js
+++ b/src/screens/feedback-screen/pip-view/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -9,7 +10,7 @@ const ContainerView = styled.View`
   justify-content: space-around;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   font-size: 21px;

--- a/src/screens/feedback-screen/problem-feedback-screen/styles.js
+++ b/src/screens/feedback-screen/problem-feedback-screen/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { RadioButton, TextInput } from 'react-native-paper';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,7 +13,7 @@ const ContainerView = styled.View`
   display: flex;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 500;
   color: ${Colors.white};
@@ -29,7 +30,7 @@ const CheckContainerItem = styled.View`
 const Option = styled(RadioButton.Android)`
 `;
 
-const LabelOption = styled.Text`
+const LabelOption = styled(Text)`
   flex: 1;
   color: ${Colors.white};
 `;

--- a/src/screens/feedback-screen/specific-problem-feedback-screen/styles.js
+++ b/src/screens/feedback-screen/specific-problem-feedback-screen/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { Button, RadioButton, TextInput } from 'react-native-paper';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,7 +13,7 @@ const ContainerView = styled.View`
   display: flex;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 500;
   color: ${Colors.white};
@@ -28,7 +29,7 @@ const CheckContainerItem = styled.View`
 const Option = styled(RadioButton.Android)`
 `;
 
-const LabelOption = styled.Text`
+const LabelOption = styled(Text)`
   flex: 1;
   color: ${Colors.white};
 `;

--- a/src/screens/feedback-screen/styles.js
+++ b/src/screens/feedback-screen/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { Slider } from '@miblanchard/react-native-slider';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -20,7 +21,7 @@ const ContainerFeedbackCard = styled.View`
   gap: 16px;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   font-size: 21px;
@@ -31,7 +32,7 @@ const Title = styled.Text`
   font-weight: 500;
 `;
 
-const Subtitle = styled.Text`
+const Subtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;
@@ -58,7 +59,7 @@ const StarsRatingTextContainer = styled.View`
   margin-bottom: 10%;
 `;
 
-const StarsRatingText = styled.Text`
+const StarsRatingText = styled(Text)`
   color: ${Colors.white};
 `;
 
@@ -74,7 +75,7 @@ const ThumbContainer = styled.View`
   right: 30px;
 `;
 
-const ThumbLabel = styled.Text`
+const ThumbLabel = styled(Text)`
   fontSize: 30px;
   text-align: center;
   color: ${Colors.white};

--- a/src/screens/guest-screen/styles.js
+++ b/src/screens/guest-screen/styles.js
@@ -1,6 +1,7 @@
 import { ActivityIndicator } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -13,14 +14,14 @@ const ContainerView = styled.View`
   background-color: ${Colors.blueBackgroundColor}
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   text-align: center;
   font-weight: 500;
 `;
 
-const Subtitle = styled.Text`
+const Subtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;

--- a/src/screens/loading-screen/styles.js
+++ b/src/screens/loading-screen/styles.js
@@ -1,6 +1,7 @@
 import { ActivityIndicator } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,7 +13,7 @@ const ContainerView = styled.View`
   padding: 24px;
 `;
 
-const TitleText = styled.Text`
+const TitleText = styled(Text)`
   font-size: 24px;
   font-weight: 500;
   text-align: center;

--- a/src/screens/pick-random-user-screen/modal/styles.js
+++ b/src/screens/pick-random-user-screen/modal/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const Container = styled.View`
   display: flex;
@@ -18,13 +19,13 @@ const Container = styled.View`
   `}
 `;
 
-const TitleModal = styled.Text`
+const TitleModal = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
 `;
 
-const UserName = styled.Text`
+const UserName = styled(Text)`
   font-size: 16px;
   font-weight: 600;
   color: ${Colors.lightGray300};

--- a/src/screens/poll-screen/answer-poll-screen/styles.js
+++ b/src/screens/poll-screen/answer-poll-screen/styles.js
@@ -1,10 +1,11 @@
 import styled from 'styled-components/native';
 import textInput from '../../../components/text-input';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ButtonsContainer = styled.View``;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 600;
   text-align: center;
@@ -12,7 +13,7 @@ const Title = styled.Text`
   color: ${Colors.white};
 `;
 
-const SecretLabel = styled.Text`
+const SecretLabel = styled(Text)`
   font-weight: 500;
   font-size: 12px;
   text-align: center;

--- a/src/screens/poll-screen/create-poll-screen/styles.js
+++ b/src/screens/poll-screen/create-poll-screen/styles.js
@@ -4,6 +4,7 @@ import { Pressable as PressableRN } from 'react-native';
 import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
 import textInput from '../../../components/text-input';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -28,14 +29,14 @@ const HeaderContainer = styled.View`
   gap: 12px;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 600;
   color: ${Colors.lightGray400};
   flex: 1;
 `;
 
-const SectionHeading = styled.Text`
+const SectionHeading = styled(Text)`
   font-weight: 500;
   font-size: 18px;
   color: ${Colors.lightGray400};
@@ -60,7 +61,7 @@ const ModeTabPressable = styled.Pressable`
   background-color: ${({ active }) => (active ? Colors.white : 'transparent')};
 `;
 
-const ModeTabText = styled.Text`
+const ModeTabText = styled(Text)`
   font-size: 16px;
   font-weight: ${({ active }) => (active ? 500 : 400)};
   color: ${({ active }) => (active ? Colors.lightGray400 : Colors.lightGray300)};
@@ -87,7 +88,7 @@ const InfoBoxContainer = styled.View`
   padding: 16px;
 `;
 
-const InfoBoxText = styled.Text`
+const InfoBoxText = styled(Text)`
   font-size: 15px;
   font-weight: 400;
   color: ${({ isQuiz }) => (isQuiz ? Colors.successText : Colors.pollInfoText)};
@@ -106,7 +107,7 @@ const StatusBoxContainer = styled.View`
   padding: 16px;
 `;
 
-const StatusBoxText = styled.Text`
+const StatusBoxText = styled(Text)`
   font-size: 15px;
   font-weight: 400;
   color: ${({ done }) => (done ? Colors.successText : Colors.warningText)};
@@ -125,7 +126,7 @@ const ToggleRow = styled.View`
   gap: 16px;
 `;
 
-const ToggleLabel = styled.Text`
+const ToggleLabel = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray300};
@@ -143,7 +144,7 @@ const Toggle = ({ value, onValueChange, children }) => (
   </ToggleRow>
 );
 
-const CheckboxLabel = styled.Text`
+const CheckboxLabel = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray400};
@@ -182,7 +183,7 @@ const AnswerTypePressable = styled.Pressable`
   background-color: ${({ active }) => (active ? Colors.blue : Colors.lightGray200)};
 `;
 
-const AnswerTypeText = styled.Text`
+const AnswerTypeText = styled(Text)`
   font-size: 17px;
   font-weight: 500;
   color: ${({ active }) => (active ? Colors.white : Colors.lightGray400)};
@@ -237,7 +238,7 @@ const CorrectBadge = styled.View`
   padding: 4px 12px;
 `;
 
-const CorrectBadgeText = styled.Text`
+const CorrectBadgeText = styled(Text)`
   font-size: 13px;
   font-weight: 400;
   color: ${Colors.successText};
@@ -296,7 +297,7 @@ const AddItemCircle = styled.View`
   background-color: ${({ disabled }) => (disabled ? Colors.lightGray200 : Colors.blue)};
 `;
 
-const AddItemLabel = styled.Text`
+const AddItemLabel = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${({ disabled }) => (disabled ? Colors.lightGray200 : Colors.lightGray300)};
@@ -320,7 +321,7 @@ const StartPollPressable = styled.Pressable`
   background-color: ${({ disabled }) => (disabled ? Colors.lightGray100 : Colors.orange)};
 `;
 
-const StartPollText = styled.Text`
+const StartPollText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${({ disabled }) => (disabled ? Colors.lightGray200 : Colors.white)};

--- a/src/screens/poll-screen/live-poll-screen/styles.js
+++ b/src/screens/poll-screen/live-poll-screen/styles.js
@@ -3,6 +3,7 @@ import { Divider } from 'react-native-paper';
 import { Pressable as PressableRN } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -27,7 +28,7 @@ const HeaderContainer = styled.View`
   gap: 12px;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 600;
   color: ${Colors.lightGray400};
@@ -46,20 +47,20 @@ const CloseButton = ({ onPress, accessibilityLabel }) => (
   </PressableRN>
 );
 
-const Subtitle = styled.Text`
+const Subtitle = styled(Text)`
   font-size: 15px;
   font-weight: 400;
   color: ${Colors.lightGray300};
 `;
 
-const SubtitleStrong = styled.Text`
+const SubtitleStrong = styled(Text)`
   font-weight: 600;
   color: ${Colors.lightGray400};
 `;
 
 const CustomDivider = styled(Divider)``;
 
-const QuestionText = styled.Text`
+const QuestionText = styled(Text)`
   font-size: 22px;
   font-weight: 400;
   color: ${Colors.lightGray400};
@@ -77,7 +78,7 @@ const ResultRow = styled.View`
   gap: 12px;
 `;
 
-const ResultLabel = styled.Text`
+const ResultLabel = styled(Text)`
   font-size: 17px;
   font-weight: 400;
   color: ${Colors.lightGray300};
@@ -100,13 +101,13 @@ const ResultBar = styled.View`
   width: ${({ percentage }) => `${percentage}%`};
 `;
 
-const ResultCount = styled.Text`
+const ResultCount = styled(Text)`
   font-size: 15px;
   font-weight: 400;
   color: ${Colors.lightGray300};
 `;
 
-const ResultPercentage = styled.Text`
+const ResultPercentage = styled(Text)`
   font-size: 17px;
   font-weight: 400;
   color: ${Colors.lightGray300};
@@ -114,7 +115,7 @@ const ResultPercentage = styled.Text`
   text-align: right;
 `;
 
-const HintText = styled.Text`
+const HintText = styled(Text)`
   font-size: 15px;
   font-weight: 400;
   color: ${Colors.lightGray300};
@@ -129,7 +130,7 @@ const PublishPressable = styled.Pressable`
   background-color: ${Colors.orange};
 `;
 
-const PublishText = styled.Text`
+const PublishText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/screens/poll-screen/modals/cant-create-poll/styles.js
+++ b/src/screens/poll-screen/modals/cant-create-poll/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components/native';
 import Colors from '../../../../constants/colors';
+import { Text } from '../../../../components/typography';
 
 const Container = styled.View`
   display: flex;
@@ -11,13 +12,13 @@ const Container = styled.View`
   border-radius: 12px;
 `;
 
-const TitleModal = styled.Text`
+const TitleModal = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.lightGray400};
 `;
 
-const TitleDesc = styled.Text`
+const TitleDesc = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   color: ${Colors.lightGray300};

--- a/src/screens/poll-screen/modals/receive-poll/styles.js
+++ b/src/screens/poll-screen/modals/receive-poll/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import Colors from '../../../../constants/colors';
 import textInput from '../../../../components/text-input';
+import { Text } from '../../../../components/typography';
 
 const Container = styled.Pressable`
   display: flex;
@@ -14,14 +15,14 @@ const InsideContainer = styled.Pressable`
   padding: 24px;
 `;
 
-const SecretLabel = styled.Text`
+const SecretLabel = styled(Text)`
   font-weight: 500;
   font-size: 12px;
   text-align: center;
   font-style: italic;
 `;
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 20px;
   font-weight: 500;
   text-align: center;

--- a/src/screens/poll-screen/previous-polls-screen/poll-card/styles.js
+++ b/src/screens/poll-screen/previous-polls-screen/poll-card/styles.js
@@ -1,10 +1,13 @@
 import styled, { css } from 'styled-components/native';
 import { Divider } from 'react-native-paper';
-import { Text, Pressable as PressableRN } from 'react-native';
+import {
+  Pressable as PressableRN,
+} from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import Pressable from '../../../../components/pressable';
 import Colors from '../../../../constants/colors';
 import UserAvatar from '../../../../components/user-avatar';
+import { Text } from '../../../../components/typography';
 
 const ContainerPollCard = styled.Pressable`
   background-color: ${Colors.white};
@@ -15,13 +18,13 @@ const ContainerPollCard = styled.Pressable`
   border-radius: 8px;
 `;
 
-const KeyText = styled.Text`
+const KeyText = styled(Text)`
   font-size: 14px;
   font-weight: 400;
   color: ${Colors.lightGray300};
 `;
 
-const PercentageText = styled.Text`
+const PercentageText = styled(Text)`
   font-size: 13px;
   font-weight: 400;
   width: 35px;
@@ -40,14 +43,14 @@ const LabelContainer = styled.View`
   gap: 4px;
 `;
 
-const TimestampText = styled.Text`
+const TimestampText = styled(Text)`
   font-size: 14px;
   font-weight: 500;
   font-style: italic;
   text-align: center;
 `;
 
-const QuestionText = styled.Text`
+const QuestionText = styled(Text)`
   font-size: 18px;
   font-weight: 400;
   color: ${Colors.lightGray300};
@@ -63,7 +66,7 @@ const PollInfoLabelContainer = styled.View`
   align-items: center;
 `;
 
-const PollInfoText = styled.Text`
+const PollInfoText = styled(Text)`
   font-weight: 400;
   font-size: 12px;
   color: ${Colors.lightGray300};
@@ -81,7 +84,7 @@ const PresenterContainerOptions = styled.View`
   flex-direction: row;
 `;
 
-const MinimizeAnswersText = styled.Text`
+const MinimizeAnswersText = styled(Text)`
   font-weight: 400;
   font-size: 12px;
   color: ${Colors.blue};
@@ -120,7 +123,7 @@ const DeleteIcon = ({ onPress }) => (
   </PressableRN>
 );
 
-const UserNameAnswer = styled.Text`
+const UserNameAnswer = styled(Text)`
   font-weight: 400;
   font-size: 12px;
   text-align: center;
@@ -129,7 +132,7 @@ const UserNameAnswer = styled.Text`
   color: ${Colors.lightGray300};
 `;
 
-const UserAnswer = styled.Text`
+const UserAnswer = styled(Text)`
   font-weight: 500;
   font-size: 12px;
   vertical-align: middle;

--- a/src/screens/poll-screen/previous-polls-screen/styles.js
+++ b/src/screens/poll-screen/previous-polls-screen/styles.js
@@ -1,14 +1,15 @@
 import styled from 'styled-components/native';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
-const Title = styled.Text`
+const Title = styled(Text)`
   font-size: 24px;
   font-weight: 600;
   text-align: center;
   padding-bottom: 24px;
 `;
 
-const NoPollText = styled.Text`
+const NoPollText = styled(Text)`
   font-size: 16px;
   font-weight: 600;
   font-style: italic;
@@ -68,7 +69,7 @@ const ContainerCentralizedView = styled.View`
 
 const NoPollsImage = styled.Image``;
 
-const NoPollsLabelTitle = styled.Text`
+const NoPollsLabelTitle = styled(Text)`
   color: ${Colors.white};
   font-size: 21px;
   text-align: center;
@@ -77,7 +78,7 @@ const NoPollsLabelTitle = styled.Text`
   padding-top: 24px;
 `;
 
-const NoPollsLabelSubtitle = styled.Text`
+const NoPollsLabelSubtitle = styled(Text)`
   color: ${Colors.white};
   font-size: 16px;
   text-align: center;

--- a/src/screens/test-components-screen/index.js
+++ b/src/screens/test-components-screen/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import * as Linking from 'expo-linking';
-import { View, Text } from 'react-native';
+import {
+  View,
+} from 'react-native';
 import Settings from '../../../settings.json';
 import SocketConnection from '../../components/socket-connection';
 import logger from '../../services/logger';
 import Styled from './styles';
+import { Text } from '../../components/typography';
 
 const TestComponentsScreen = (props) => {
   const { jUrl } = props;

--- a/src/screens/timer-screen/TimerPicker/styles.js
+++ b/src/screens/timer-screen/TimerPicker/styles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+import { Text } from '../../../components/typography';
 
 const Button = styled.TouchableOpacity`
   border-width: 1px;
@@ -8,7 +9,7 @@ const Button = styled.TouchableOpacity`
   align-self: center;
 `;
 
-const ButtonText = styled.Text`
+const ButtonText = styled(Text)`
   font-size: 18px;
 `;
 
@@ -29,7 +30,7 @@ const DoneButton = styled.TouchableOpacity`
   border-color: #ccc;
 `;
 
-const DoneText = styled.Text`
+const DoneText = styled(Text)`
   font-size: 18px;
   font-weight: bold;
 `;

--- a/src/screens/timer-screen/styles.js
+++ b/src/screens/timer-screen/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import { Divider } from 'react-native-paper';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const Container = styled.View`
   width: 100%;
@@ -30,14 +31,14 @@ const TimerBody = styled.View`
   align-items: center;
 `;
 
-const TimerText = styled.Text`
+const TimerText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.white};
   padding-left: 12px;
 `;
 
-const TimerValue = styled.Text`
+const TimerValue = styled(Text)`
   font-size: 24px;
   font-weight: bold;
   color: ${Colors.lightGray400};

--- a/src/screens/transfer-screen/styles.js
+++ b/src/screens/transfer-screen/styles.js
@@ -1,6 +1,7 @@
 import { IconButton } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -13,14 +14,14 @@ const ContainerView = styled.View`
   background-color: #06172A;
 `;
 
-const TitleText = styled.Text`
+const TitleText = styled(Text)`
   font-size: 21px;
   font-weight: 500;
   text-align: center;
   color: ${Colors.white};
 `;
 
-const SubtitleText = styled.Text`
+const SubtitleText = styled(Text)`
   font-size: 16px;
   font-weight: 400;
   text-align: center;

--- a/src/screens/user-join-screen/index.js
+++ b/src/screens/user-join-screen/index.js
@@ -1,6 +1,5 @@
 import { useMutation, useSubscription } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
-import { Text } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import React, { useEffect } from 'react';
@@ -14,6 +13,7 @@ import {
 import { disconnectLiveKitRoom } from '../../services/livekit';
 import logger from '../../services/logger';
 import Styled from './styles';
+import { Text } from '../../components/typography';
 
 const UserJoinScreen = () => {
   const navigation = useNavigation();

--- a/src/screens/user-join-screen/styles.js
+++ b/src/screens/user-join-screen/styles.js
@@ -1,6 +1,7 @@
 import { ActivityIndicator } from 'react-native-paper';
 import styled from 'styled-components/native';
 import Colors from '../../constants/colors';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -12,7 +13,7 @@ const ContainerView = styled.View`
   padding: 24px;
 `;
 
-const TitleText = styled.Text`
+const TitleText = styled(Text)`
   font-size: 24px;
   font-weight: 500;
   text-align: center;

--- a/src/screens/user-participants-screen/guest-policy/styles.js
+++ b/src/screens/user-participants-screen/guest-policy/styles.js
@@ -2,6 +2,7 @@ import { Divider } from 'react-native-paper';
 import styled from 'styled-components/native';
 import iconButton from '../../../components/icon-button';
 import Colors from '../../../constants/colors';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -28,7 +29,7 @@ const GuestPolicyTop = styled.View`
   padding: 12px;
 `;
 
-const GuestPolicyTopText = styled.Text`
+const GuestPolicyTopText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/screens/user-participants-screen/styles.js
+++ b/src/screens/user-participants-screen/styles.js
@@ -5,6 +5,7 @@ import userAvatar from '../../components/user-avatar';
 import Colors from '../../constants/colors';
 import Pressable from '../../components/pressable';
 import iconButton from '../../components/icon-button';
+import { Text } from '../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -41,7 +42,7 @@ const CardPressable = styled(Pressable).attrs(() => ({
   `}
 `;
 
-const UserName = styled.Text`
+const UserName = styled(Text)`
   color: black;
   padding-left: 20px;
   font-size: 16px;
@@ -79,7 +80,7 @@ const GuestPolicyIcon = styled(iconButton)`
   right: 0px;
 `;
 
-const GuestPolicyText = styled.Text`
+const GuestPolicyText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.white};

--- a/src/screens/user-participants-screen/waiting-users/styles.js
+++ b/src/screens/user-participants-screen/waiting-users/styles.js
@@ -3,6 +3,7 @@ import { Divider } from 'react-native-paper';
 import Colors from '../../../constants/colors';
 import userAvatar from '../../../components/user-avatar';
 import iconButton from '../../../components/icon-button';
+import { Text } from '../../../components/typography';
 
 const ContainerView = styled.View`
   width: 100%;
@@ -30,7 +31,7 @@ const WaitingUsersTop = styled.View`
   padding: 12px;
 `;
 
-const WaitingUsersTopText = styled.Text`
+const WaitingUsersTopText = styled(Text)`
   font-size: 18px;
   font-weight: 500;
   color: ${Colors.white};
@@ -57,7 +58,7 @@ const WaitingUsersView = styled.View`
   `}
 `;
 
-const UserName = styled.Text`
+const UserName = styled(Text)`
   color: black;
   padding-left: 20px;
   font-size: 16px;
@@ -92,7 +93,7 @@ const AccRejContainer = styled.View`
   gap: 4px
 `;
 
-const NoPendingUsersText = styled.Text`
+const NoPendingUsersText = styled(Text)`
   font-size: 16px;
   font-weight: 500;
   font-style: italic;


### PR DESCRIPTION
## Summary

Standardizes the SDK typography on **Nunito Sans**, per the Figma reference ([App 2025 – node 7751-5408](https://www.figma.com/design/lKWmlXFcCGIdOyBMCzoSUY/App-2025?node-id=7751-5408)). Refs mconf/conferenciaweb-portal-mobile#380.

## What changed

- **Dependency**: `@expo-google-fonts/nunito-sans@0.4.2`. Faces bundled: 300–800 upright, 400/600/700 italic.
- **`src/constants/fonts.js`**: single source of truth. Exports the assets to load (`FONT_ASSETS`), the `Fonts` names (`regular`, `medium`, `semiBold`, `bold`, …), `fontFamilyFor(weight, style)` (maps any RN `fontWeight`/`fontStyle` to the closest bundled face) and `navigationFonts` for the react-navigation theme.
- **`src/components/typography`**: `Text` / `TextInput` drop-in replacements for the react-native ones. They resolve `font-weight`/`font-style` to the right face at render time and drop `fontWeight`, so `styles.js` keep using `font-weight: 600;` as in Figma and Android does not synthesize a fake bold on top of a real bold face. Every `styled.Text` and raw RN `Text` now goes through them (`styled(Text)`).
- **react-native-paper**: `src/constants/paper-theme.js` builds an MD3 theme whose type variants use Nunito Sans while keeping the default palette (the SDK never had a `PaperProvider`, so colors are unchanged). A `PaperProvider` is mounted at the root so `Button`, `TextInput` and `Menu` pick it up.
- **react-navigation**: theme `fonts` set on the `NavigationContainer` (drawer labels, headers). Drawer labels and paper button labels that live outside styled `Text` get an explicit `fontFamily`.
- **Loading**: `useFonts` in `App.js`; the SDK renders nothing until the faces are registered and falls back to the system font if loading fails.

## Why not a global `Text` patch

RN 0.81's `Text` is no longer a `forwardRef`, so there is no `Text.render` to intercept. Mapping weights centrally in a wrapper component is the reliable alternative.

## Testing

- `npm run lint`: no new problems vs `master` (remaining errors are pre-existing).
- `npx tsc --noEmit --skipLibCheck` clean, `npm run build` compiles.
- Weight → face mapping exercised with 13 cases in Node.
- **Not yet run on a device** (none available here). Please check on iOS and Android: chat, participants list, polls, paper buttons/inputs, drawer labels.

## Notes

- The host app (conferenciaweb-portal-mobile) only sees this inside the conference after a new SDK tag is released and bumped there.
- Per-screen fine-tuning against Figma (sizes/weights) is out of scope here; this PR standardizes the default typeface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
