### PR TITLE
feat(layout): support landscape on the session-viewing screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,12 +1,14 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { NavigationContainer, DefaultTheme, NavigationIndependentTree } from '@react-navigation/native';
-import { OrientationLocker, PORTRAIT } from 'react-native-orientation-locker';
+import {
+  NavigationContainer, DefaultTheme, NavigationIndependentTree, useNavigationContainerRef
+} from '@react-navigation/native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { store } from './src/store/redux/store';
 // components
 import InCallManagerController from './src/app-content/in-call-manager';
 import LocalesController from './src/app-content/locales';
+import OrientationController from './src/app-content/orientation';
 import AppStatusBar from './src/components/status-bar';
 import NavigatorHandler from './src/screens/navigator-handler';
 import { disconnectLiveKitRoom } from './src/services/livekit';
@@ -46,6 +48,14 @@ const App = (props) => {
     || defaultJoinURL();
   const _onLeaveSession = leaveSessionFactory(onLeaveSession);
 
+  // The orientation policy is keyed by the deepest focused route, which only
+  // the container ref can resolve across the nested stack/drawer navigators.
+  const navigationRef = useNavigationContainerRef();
+  const [routeName, setRouteName] = useState();
+  const syncRouteName = useCallback(() => {
+    setRouteName(navigationRef.getCurrentRoute()?.name);
+  }, [navigationRef]);
+
   useEffect(() => {
     injectStore();
   }, []);
@@ -54,8 +64,13 @@ const App = (props) => {
     <KeyboardProvider>
       <Provider store={store}>
         <NavigationIndependentTree>
-          <NavigationContainer theme={MyTheme}>
-            <OrientationLocker orientation={PORTRAIT} />
+          <NavigationContainer
+            ref={navigationRef}
+            theme={MyTheme}
+            onReady={syncRouteName}
+            onStateChange={syncRouteName}
+          >
+            <OrientationController routeName={routeName} />
             <NavigatorHandler
               {...props}
               joinURL={_joinURL}

--- a/ios/bbbmobile/AppDelegate.swift
+++ b/ios/bbbmobile/AppDelegate.swift
@@ -32,6 +32,17 @@ public class AppDelegate: ExpoAppDelegate {
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
+  // react-native-orientation-locker: UIKit asks the delegate which
+  // orientations are allowed; without this the JS lock calls are ignored and
+  // Info.plist (all orientations) wins. Replaces the override that lived in
+  // the pre-Swift AppDelegate.mm.
+  public override func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    return Orientation.getOrientation()
+  }
+
   // Linking API
   public override func application(
     _ app: UIApplication,

--- a/ios/bbbmobile/bbbmobile-Bridging-Header.h
+++ b/ios/bbbmobile/bbbmobile-Bridging-Header.h
@@ -1,3 +1,5 @@
 //
 // Use this file to import your target's public headers that you would like to expose to Swift.
 //
+
+#import "Orientation.h"

--- a/src/app-content/orientation/index.js
+++ b/src/app-content/orientation/index.js
@@ -1,0 +1,13 @@
+import { OrientationLocker } from 'react-native-orientation-locker';
+import { getOrientationForRoute } from '../../constants/orientation';
+
+// The app-wide orientation lock. It is the bottom entry of the
+// OrientationLocker stack, so any screen that mounts its own
+// <OrientationLocker> (e.g. the fullscreen presentation forcing LANDSCAPE)
+// still takes precedence while mounted. Before any navigator is ready
+// `routeName` is undefined and the policy falls back to portrait.
+const OrientationController = ({ routeName }) => (
+  <OrientationLocker orientation={getOrientationForRoute(routeName)} />
+);
+
+export default OrientationController;

--- a/src/components/actions-bar/bottom-sheet-actions-bar/index.js
+++ b/src/components/actions-bar/bottom-sheet-actions-bar/index.js
@@ -1,7 +1,7 @@
 import React, {
   useCallback, useEffect, useMemo, useRef
 } from 'react';
-import { View } from 'react-native';
+import { View, useWindowDimensions } from 'react-native';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useRoute } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -21,6 +21,7 @@ const BottomSheetActionsBar = ({ alwaysOpen }) => {
   const bottomSheetRef = useRef(null);
   const route = useRoute();
   const orientation = useOrientation();
+  const { height: windowHeight } = useWindowDimensions();
   const dispatch = useDispatch();
 
   const detailedInfo = useSelector((state) => state.layout.detailedInfo);
@@ -40,12 +41,15 @@ const BottomSheetActionsBar = ({ alwaysOpen }) => {
     );
   };
 
+  // Both orientations expose the expanded point (the drawer's "audio device"
+  // shortcut snaps to index 1); in landscape the window is short, so cap it
+  // and let the inner BottomSheetScrollView scroll the rest.
   const snapPoints = useMemo(() => {
-    if (orientation === 'PORTRAIT') {
-      return [LayoutConstants.ACTIONS_BAR_COLLAPSED_HEIGHT, handleSizeOfActionsBar()];
-    }
-    return [LayoutConstants.ACTIONS_BAR_COLLAPSED_HEIGHT];
-  }, [orientation]);
+    const expanded = orientation === 'PORTRAIT'
+      ? handleSizeOfActionsBar()
+      : Math.min(handleSizeOfActionsBar(), Math.round(windowHeight * 0.9));
+    return [LayoutConstants.ACTIONS_BAR_COLLAPSED_HEIGHT, expanded];
+  }, [orientation, windowHeight]);
 
   // callbacks
   const handleSheetChanges = useCallback((index) => {

--- a/src/components/chat/bottom-sheet-chat/index.js
+++ b/src/components/chat/bottom-sheet-chat/index.js
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { FlatList } from 'react-native-gesture-handler';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import Colors from '../../../constants/colors';
 import { useBottomSheetBackHandler } from '../../../hooks/useBottomSheetBackHandler';
@@ -22,6 +23,7 @@ import Styled from './styles';
 
 const BottomSheetChat = () => {
   const height = useHeaderHeight();
+  const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const { data } = useSubscription(Queries.CHAT_MESSAGE_PUBLIC_SUB);
   const [dispatchSendMessage] = useMutation(Queries.SEND_MESSAGE_MUTATION);
@@ -89,6 +91,7 @@ const BottomSheetChat = () => {
         onChange={handleSheetChanges}
         enablePanDownToClose
         enableDynamicSizing={false}
+        topInset={insets.top}
         style={topShadowStyle}
       >
         {renderEmptyChatHandler()}

--- a/src/components/custom-drawer/drawer-navigator/index.js
+++ b/src/components/custom-drawer/drawer-navigator/index.js
@@ -1,8 +1,8 @@
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { useIsFocused } from '@react-navigation/native';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, BackHandler } from "react-native";
+import { Alert, BackHandler, useWindowDimensions } from "react-native";
 import { useDispatch, useSelector } from 'react-redux';
 import Settings from '../../../../settings.json';
 import { ActivitySignProvider } from '../../../app-content/ActivitySign';
@@ -13,6 +13,7 @@ import useMeeting from '../../../graphql/hooks/useMeeting';
 import useUserCount from '../../../graphql/hooks/useUserCount';
 import useModalListener from '../../../hooks/listeners/use-modal-listener';
 import useAppState from '../../../hooks/use-app-state';
+import { useOrientation } from '../../../hooks/use-orientation';
 import BreakoutRoomScreen from '../../../screens/breakout-room-screen';
 import FullscreenWrapperScreen from '../../../screens/fullscreen-wrapper-screen';
 import InsideBreakoutRoomScreen from '../../../screens/inside-breakout-room-screen';
@@ -68,8 +69,22 @@ const DrawerNavigator = ({
   const users = currentUserCount?.user_aggregate?.aggregate?.count || 0;
   const isCameraConnected = useSelector((state) => state.video.isConnected);
   const dispatch = useDispatch();
+  const isLandscape = useOrientation() === 'LANDSCAPE';
+  const { width: windowWidth } = useWindowDimensions();
 
   useModalListener();
+
+  // The drawer is a fixed share of the window in portrait; in landscape that
+  // share would swallow most of the screen, so clamp it to a sane panel width.
+  const screenOptions = useMemo(() => ({
+    ...Styled.ScreenOptions,
+    drawerStyle: {
+      ...Styled.ScreenOptions.drawerStyle,
+      width: isLandscape
+        ? Math.min(Math.round(windowWidth * 0.5), Styled.LANDSCAPE_DRAWER_MAX_WIDTH)
+        : Styled.ScreenOptions.drawerStyle.width,
+    },
+  }), [isLandscape, windowWidth]);
 
   useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -113,7 +128,7 @@ const DrawerNavigator = ({
             meetingUrl={meetingUrl}
           />
         )}
-        screenOptions={Styled.ScreenOptions}
+        screenOptions={screenOptions}
       >
         <Drawer.Screen
           name="Main"

--- a/src/components/custom-drawer/drawer-navigator/styles.js
+++ b/src/components/custom-drawer/drawer-navigator/styles.js
@@ -50,6 +50,8 @@ const BetaTag = styled(Tag)`
   right: 12px;
 `;
 
+const LANDSCAPE_DRAWER_MAX_WIDTH = 360;
+
 const ScreenOptions = {
   contentOptions: {
     style: {
@@ -92,4 +94,5 @@ export default {
   BetaTag,
   IconMaterial,
   ScreenOptions,
+  LANDSCAPE_DRAWER_MAX_WIDTH,
 };

--- a/src/components/video/video-grid/index.js
+++ b/src/components/video/video-grid/index.js
@@ -1,19 +1,33 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { useCallback, useState } from 'react';
-import { Dimensions, FlatList } from 'react-native';
+import { FlatList } from 'react-native';
 import { useSelector } from 'react-redux';
 import useCurrentUser from '../../../graphql/hooks/useCurrentUser';
 import useUserList from '../../../graphql/hooks/useUserList';
+import { useOrientation } from '../../../hooks/use-orientation';
 import Styled from './styles';
 
-const DEVICE_HEIGHT = parseInt(Dimensions.get('window').height, 10);
+const getNumOfColumns = ({ usersCount, isLandscape, isPresentationOpen }) => {
+  if (isLandscape) {
+    // With the presentation open the cameras become a side column next to
+    // it; otherwise two wide tiles per row fill the screen.
+    if (isPresentationOpen) return 1;
+    return usersCount > 1 ? 2 : 1;
+  }
+  return usersCount > 2 ? 2 : 1;
+};
 
 const GridView = () => {
   const isPresentationOpen = useSelector((state) => state.layout.isPresentationOpen);
   const { data: userData } = useUserList();
   const { data: currentUserData } = useCurrentUser();
+  const isLandscape = useOrientation() === 'LANDSCAPE';
   const videoUsersCopy = userData?.user.filter(() => true);
+  const usersCount = videoUsersCopy?.length || 0;
   const [numOfColumns, setNumOfColumns] = useState(1);
+  // Measured instead of derived from the window size: it already accounts
+  // for the header, the indicator bar and the current orientation.
+  const [gridHeight, setGridHeight] = useState(0);
   const currentUserId = currentUserData?.user_current[0].userId;
 
   const removeCurrentUserFromVideoUsers = () => {
@@ -28,9 +42,13 @@ const GridView = () => {
 
   useFocusEffect(
     useCallback(() => {
-      setNumOfColumns(userData?.user.length > 2 ? 2 : 1);
-    }, [userData])
+      setNumOfColumns(getNumOfColumns({ usersCount, isLandscape, isPresentationOpen }));
+    }, [usersCount, isLandscape, isPresentationOpen])
   );
+
+  const onGridLayout = useCallback(({ nativeEvent }) => {
+    setGridHeight(Math.round(nativeEvent.layout.height));
+  }, []);
 
   const renderItem = (videoUser) => {
     const { item: vuItem } = videoUser;
@@ -52,9 +70,10 @@ const GridView = () => {
 
     return (
       <Styled.Item
-        usersCount={videoUsersCopy.length}
-        dimensionHeight={DEVICE_HEIGHT - 90}
+        usersCount={usersCount}
+        dimensionHeight={gridHeight}
         isPresentationOpen={isPresentationOpen}
+        isLandscape={isLandscape}
       >
         <Styled.VideoListItem
           cameraId={cameraId?.streamId || null}
@@ -65,7 +84,7 @@ const GridView = () => {
           local={local}
           visible={visible}
           isGrid
-          usersCount={videoUsersCopy.length}
+          usersCount={usersCount}
           userRole={role}
           userEmoji={emoji}
           raiseHand={raiseHand}
@@ -75,23 +94,26 @@ const GridView = () => {
   };
 
   return (
-    <>
+    <Styled.GridContainer isLandscape={isLandscape} onLayout={onGridLayout}>
       <Styled.ContainerViewItem
         isPresentationOpen={isPresentationOpen}
-        dimensionHeight={DEVICE_HEIGHT - 90}
+        isLandscape={isLandscape}
+        dimensionHeight={gridHeight}
       >
         <Styled.ContentArea />
       </Styled.ContainerViewItem>
-      <FlatList
-        data={videoUsersCopy}
-        style={Styled.styles.container}
-        renderItem={renderItem}
-        numColumns={numOfColumns}
-        initialNumToRender={2}
-        key={numOfColumns}
-        disableIntervalMomentum
-      />
-    </>
+      {gridHeight > 0 && (
+        <FlatList
+          data={videoUsersCopy}
+          style={Styled.styles.container}
+          renderItem={renderItem}
+          numColumns={numOfColumns}
+          initialNumToRender={2}
+          key={`${numOfColumns}-${isLandscape}`}
+          disableIntervalMomentum
+        />
+      )}
+    </Styled.GridContainer>
   );
 };
 

--- a/src/components/video/video-grid/styles.js
+++ b/src/components/video/video-grid/styles.js
@@ -12,123 +12,98 @@ const VideoListItem = styled(VideoContainer)`
 const ContentArea = styled(contentArea)`
 `;
 
+// Landscape: the presentation takes this share of the width and the cameras
+// stack in the remaining column.
+const LANDSCAPE_CONTENT_WIDTH = '65%';
+
+// Tile size as a function of the grid box (dimensionHeight is the measured
+// height of the whole grid area, presentation included). Portrait keeps the
+// historical thirds-based layout; landscape splits rows in halves because the
+// box is short and wide.
+const getItemSize = ({
+  usersCount, dimensionHeight, isPresentationOpen, isLandscape
+}) => {
+  const H = dimensionHeight || 0;
+  const px = (fraction) => `${parseInt(H * fraction, 10)}px`;
+
+  if (isLandscape) {
+    if (isPresentationOpen) {
+      // Single side column next to the presentation.
+      return { width: '100%', height: usersCount > 1 ? px(1 / 2) : px(1) };
+    }
+    if (usersCount <= 1) return { width: '100%', height: px(1) };
+    if (usersCount === 2) return { width: '50%', height: px(1) };
+    return { width: '50%', height: px(1 / 2), fillRow: usersCount % 2 === 1 };
+  }
+
+  if (isPresentationOpen) {
+    if (usersCount <= 1) return { width: '100%', height: px(2 / 3) };
+    if (usersCount === 2) return { width: '100%', height: px(1 / 3) };
+    return { width: '50%', height: px(1 / 3), fillRow: usersCount % 2 === 1 };
+  }
+
+  if (usersCount <= 1) return { width: '100%', height: px(1) };
+  if (usersCount === 2) return { width: '100%', height: px(1 / 2) };
+  if (usersCount <= 4) return { width: '50%', height: px(1 / 2), fillRow: usersCount % 2 === 1 };
+  return { width: '50%', height: px(1 / 3), fillRow: usersCount % 2 === 1 };
+};
+
 const Item = styled.View`
   display: flex;
   background-color: #d0c4cb;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
 
-  ${({ dimensionHeight, isPresentationOpen }) => dimensionHeight // 1 user
-  && isPresentationOpen
-  && `
-    height: ${parseInt((dimensionHeight * 2) / 3, 10)}px;
-  `}
-
-  ${({ dimensionHeight, usersCount, isPresentationOpen }) => dimensionHeight // 2 user
-  && isPresentationOpen
-  && usersCount === 2
-  && `
-    height: ${parseInt((dimensionHeight) / 3, 10)}px;
-  `}
-
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 0
-  && isPresentationOpen
-  && usersCount > 2
-  && `
-      width: 50%;
-      height: ${parseInt((dimensionHeight) / 3, 10)}px;
-  `}
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 1
-  && isPresentationOpen
-  && usersCount > 2
-  && `
-      width: 50%;
-      flex-grow: 1;
-      flex-shrink: 1;
-      flex-basis: 0;
-      height: ${parseInt((dimensionHeight) / 3, 10)}px;
-  `}
-
-  ${({ dimensionHeight, isPresentationOpen }) => dimensionHeight // 1 user
-  && !isPresentationOpen
-  && `
-    height: ${parseInt((dimensionHeight * 3) / 3, 10)}px;
-  `}
-
-  ${({ dimensionHeight, usersCount, isPresentationOpen }) => dimensionHeight // 2 user
-  && !isPresentationOpen
-  && usersCount === 2
-  && `
-    height: ${parseInt((dimensionHeight * 1.5) / 3, 10)}px;
-  `}
-
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 0
-  && !isPresentationOpen
-  && usersCount > 2
-  && `
-      width: 50%;
-      height: ${parseInt((dimensionHeight * 1.5) / 3, 10)}px;
-  `}
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 1
-  && !isPresentationOpen
-  && usersCount > 2
-  && `
-      width: 50%;
-      flex-grow: 1;
-      flex-shrink: 1;
-      flex-basis: 0;
-      height: ${parseInt((dimensionHeight * 1.5) / 3, 10)}px;
-  `}
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 0
-  && !isPresentationOpen
-  && usersCount > 4
-  && `
-      width: 50%;
-      height: ${parseInt((dimensionHeight * 1) / 3, 10)}px;
-  `}
-
-  ${({ usersCount, dimensionHeight, isPresentationOpen }) => usersCount % 2 === 1
-  && !isPresentationOpen
-  && usersCount > 4
-  && `
-      width: 50%;
-      flex-grow: 1;
-      flex-shrink: 1;
-      flex-basis: 0;
-      height: ${parseInt((dimensionHeight * 1) / 3, 10)}px;
-  `}
-
+  ${(props) => {
+    const { width, height, fillRow } = getItemSize(props);
+    return `
+      width: ${width};
+      height: ${height};
+      ${fillRow ? `
+        flex-grow: 1;
+        flex-shrink: 1;
+        flex-basis: 0;
+      ` : ''}
+    `;
+  }}
 `;
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     width: '100%',
   }
 });
+
+// Wraps presentation + camera list; measured by the grid to size the tiles.
+// Column in portrait (presentation above the cameras), row in landscape
+// (presentation beside them).
+const GridContainer = styled.View`
+  flex: 1;
+  width: 100%;
+  flex-direction: ${({ isLandscape }) => (isLandscape ? 'row' : 'column')};
+`;
 
 const ContainerViewItem = styled.View`
   display: flex;
   background-color: #d0c4cb;
   align-items: center;
   justify-content: center;
-  width: 100%;
 
   ${({ isPresentationOpen }) => !isPresentationOpen
   && `
       display: none;
   `}
 
-  ${({ dimensionHeight }) => dimensionHeight
-  && `
-    height: ${parseInt(dimensionHeight / 3, 10)}px;
-  `}
+  ${({ isLandscape, dimensionHeight }) => (isLandscape
+    ? `
+      width: ${LANDSCAPE_CONTENT_WIDTH};
+      height: 100%;
+    `
+    : `
+      width: 100%;
+      height: ${parseInt((dimensionHeight || 0) / 3, 10)}px;
+    `)}
 `;
 
 const SessionAloneTitle = styled.Text`
@@ -208,6 +183,7 @@ export default {
   ContentArea,
   styles,
   Item,
+  GridContainer,
   ContainerViewItem,
   SessionAloneTitle,
   RenderSessionAlone,

--- a/src/constants/orientation.js
+++ b/src/constants/orientation.js
@@ -1,0 +1,30 @@
+import { PORTRAIT, UNLOCK } from 'react-native-orientation-locker';
+
+// Single source of truth for which screens may follow the device rotation.
+// Route names are the deepest focused route reported by the navigation
+// container (drawer/stack screen names), so nested navigators (poll,
+// participants) resolve to their inner route names and stay portrait.
+//
+// Only the session-viewing surfaces rotate: the conference itself, the
+// fullscreen viewer (webcam / presentation / screenshare) and the embedded
+// breakout instance (whose own nested App applies this same policy to its
+// inner routes). Everything else (join/lobby, feedback, end session, the
+// drawer's forms and lists) is designed as a vertical layout and stays
+// portrait.
+//
+// UNLOCK (not ALL_ORIENTATIONS_BUT_UPSIDE_DOWN) because the Android side of
+// react-native-orientation-locker 1.7.0 does not implement the latter.
+const ROTATABLE_ROUTES = new Set([
+  'Main',
+  'FullscreenWrapperScreen',
+  'InsideBreakoutRoomScreen',
+]);
+
+export const getOrientationForRoute = (routeName) => (
+  ROTATABLE_ROUTES.has(routeName) ? UNLOCK : PORTRAIT
+);
+
+export default {
+  ROTATABLE_ROUTES,
+  getOrientationForRoute,
+};

--- a/src/hooks/use-orientation.js
+++ b/src/hooks/use-orientation.js
@@ -1,22 +1,9 @@
-import { useEffect, useState } from 'react';
-import { Dimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 
+// Derived from the live window size so it is correct on first render too
+// (a screen mounted while the device is already rotated used to report
+// PORTRAIT until the next dimension change).
 export function useOrientation() {
-  const [orientation, setOrientation] = useState('PORTRAIT');
-
-  useEffect(() => {
-    const subscription = Dimensions.addEventListener(
-      'change',
-      ({ window: { width, height } }) => {
-        if (width < height) {
-          setOrientation('PORTRAIT');
-        } else {
-          setOrientation('LANDSCAPE');
-        }
-      }
-    );
-    return () => subscription?.remove();
-  }, []);
-
-  return orientation;
+  const { width, height } = useWindowDimensions();
+  return width < height ? 'PORTRAIT' : 'LANDSCAPE';
 }

--- a/src/screens/feedback-screen/index.js
+++ b/src/screens/feedback-screen/index.js
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BackHandler, Platform } from 'react-native';
-import { OrientationLocker, PORTRAIT } from 'react-native-orientation-locker';
 import { useSelector } from 'react-redux';
 import Settings from '../../../settings.json';
 import PrimaryButton from '../../components/buttons/primary-button';
@@ -171,7 +170,6 @@ const FeedbackScreen = (props) => {
           </PrimaryButton>
         </Styled.QuitSessionButtonContainer>
       </Styled.ContainerFeedbackCard>
-      <OrientationLocker orientation={PORTRAIT} />
     </Styled.ContainerView>
   );
 };

--- a/src/screens/main-conference-screen/styles.js
+++ b/src/screens/main-conference-screen/styles.js
@@ -10,12 +10,6 @@ const ContainerView = styled.View`
   display: flex;
   align-items: center;
   justify-content: space-around;
-
-  ${({ orientation }) => orientation === 'LANDSCAPE'
-    && `
-    flex-direction: row;
-    justify-content: center;
-  `}
 `;
 
 const TopIndicatorBar = styled.View`


### PR DESCRIPTION
Closes #1104. Also addresses #805, #838 and #1084.

## Summary

Adds landscape support to the screens where the user actually watches the session, and keeps everything else in portrait through a single, central orientation policy.

### Which screens rotate

| Screen | Orientation | Why |
|---|---|---|
| `Main` (conference: camera grid + presentation + actions bar + chat) | follows device | primary session-viewing surface |
| `FullscreenWrapperScreen` (webcam / presentation / screenshare) | follows device; presentation still forces LANDSCAPE | media viewer |
| `InsideBreakoutRoomScreen` | follows device | the embedded breakout instance applies this same policy to its own routes |
| Join / guest lobby / loading / transfer / feedback flow / end session | portrait | vertical forms |
| Drawer screens (polls, participants, language, breakout, notes, timer) | portrait | forms and lists designed vertically |

The list lives in `src/constants/orientation.js` (`ROTATABLE_ROUTES`). Participants, language, timer, previous polls and breakout still carry leftover landscape styles from 2023, so adding them is a one-line change if we decide the rotate-back on navigation is worse than the layout risk.

## Changes

- **Central orientation policy.** The app-wide `OrientationLocker` in `App.js` now takes its orientation from the focused route (`navigationRef.getCurrentRoute()` on `onReady`/`onStateChange`). Screens that mount their own locker (fullscreen presentation → LANDSCAPE) still stack above it. Removed the redundant PORTRAIT locker from the feedback screen.
- **`useOrientation` derives from `useWindowDimensions`.** It used to start as `PORTRAIT` until the first change event, so a screen mounted while already rotated read the wrong value.
- **Video grid in landscape.** Presentation on the left, cameras in a column on the right (two wide tiles per row when the presentation is closed). Tile sizes come from the measured grid box (`onLayout`) instead of a module-level `Dimensions.get` captured at startup. The ten conditional style blocks were rewritten as a `getItemSize()` function; the portrait mapping is unchanged.
- **Actions bar.** The expanded snap point now exists in landscape too (capped at 90% of the window, inner scroll view handles the rest). Before, the drawer's audio-device shortcut called `snapToIndex(1)` on a one-entry snap list in landscape.
- **Chat bottom sheet (#838).** `topInset` from the safe-area insets so the sheet stops below the status bar / notch.
- **Drawer width (#805).** Clamped in landscape to 50% of the window, max 360px.
- **iOS lock (#1084).** Restored `application(_:supportedInterfaceOrientationsFor:)` returning `Orientation.getOrientation()` in `AppDelegate.swift` plus the bridging-header import. The override existed in the old `AppDelegate.mm` and was lost in the Swift migration, so the JS lock calls were being ignored on iOS.

Note: rotatable routes use `UNLOCK` rather than `ALL_ORIENTATIONS_BUT_UPSIDE_DOWN` because the Android side of `react-native-orientation-locker` 1.7.0 does not implement the latter.

## Verification

- `npm run lint:file` on every touched file: no new errors (the ones in `drawer-navigator/index.js` and `feedback-screen/index.js` pre-exist on `master`).
- `npm run build` compiles.
- **Not run on device yet.** The landscape grid, the `onLayout` sizing and especially the iOS `AppDelegate.swift` change need a device/simulator pass; the Swift snippet was not compiled here (Linux host).
- The embedded breakout stays portrait until the `bbb-breakout-sdk` tag is bumped to include this change, since the inner instance mounts its own locker on top.

## Test plan

- [ ] Android: rotate on Main with presentation open / closed, 1, 2, 3, 5 users
- [ ] Android: open drawer in landscape (width), open chat in landscape, expand actions bar in landscape
- [ ] Android: navigate Main → Participants while landscape (should rotate back to portrait)
- [ ] Android: fullscreen webcam rotates; fullscreen presentation forces landscape; exiting restores
- [ ] iOS: portrait lock actually holds on join/feedback screens (#1084); Main rotates; chat sheet clears the notch (#838)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
