### PR TITLE
fix(external-video): YouTube error 153 and Eduplay support

### DIFF
--- a/src/components/external-video/index.js
+++ b/src/components/external-video/index.js
@@ -1,61 +1,65 @@
 import { useSubscription } from '@apollo/client';
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import useCurrentUser from '../../graphql/hooks/useCurrentUser';
+import logger from '../../services/logger';
 import WebViewPlayer from './players/webview';
 import YouTubePlayer from './players/youtube';
+import EduplayPlayer, { canPlay as canPlayEduplay } from './players/eduplay';
 import { EXTERNAL_VIDEO_SUBSCRIPTION } from './queries';
 import Styled from './styles';
+
+const YOUTUBE_REGEX = /youtube\.com|youtu\.be/;
+
+const getPlayerType = (url) => {
+  if (!url) return 'unknown';
+  if (YOUTUBE_REGEX.test(url)) return 'youtube';
+  if (canPlayEduplay(url)) return 'eduplay';
+  // if (/vimeo\.com/.test(url)) return 'vimeo';
+  // if (/twitch\.tv/.test(url)) return 'twitch';
+  // if (/dailymotion\.com/.test(url)) return 'dailymotion';
+  // if (url.endsWith('.mp4') || url.endsWith('.m3u8')) return 'mp4';
+  return 'unknown';
+};
+
+// Same formula as mconf-live's `calculateCurrentTime`: while paused the
+// position is exactly what the presenter last reported; while playing it is
+// that position plus the wall-clock time elapsed since the last update.
+const calculateCurrentTime = (externalVideo) => {
+  const playerCurrentTime = externalVideo?.playerCurrentTime ?? 0;
+  const updatedAt = new Date(externalVideo?.updatedAt ?? Date.now()).getTime();
+  const isPaused = !externalVideo?.playerPlaying;
+
+  if (isPaused) return playerCurrentTime;
+
+  return playerCurrentTime + (Date.now() - updatedAt) / 1000;
+};
 
 const ExternalVideo = forwardRef(({ url }, ref) => {
   const playerRef = useRef();
   const { t } = useTranslation();
   const { data: currentUserData } = useCurrentUser();
 
-  const {
-    data: externalVideoData,
-    loading: externalVideoLoading,
-    error: externalVideoError,
-  } = useSubscription(EXTERNAL_VIDEO_SUBSCRIPTION);
+  const { data: externalVideoData } = useSubscription(EXTERNAL_VIDEO_SUBSCRIPTION, {
+    onError: (error) => {
+      logger.error({
+        logCode: 'external_video_subscription_error',
+        extraInfo: { errorMessage: error?.message },
+      }, 'External video subscription failed');
+    },
+  });
 
-  useEffect(() => {
-    if (!externalVideoLoading && externalVideoError) {
-      console.error("externalVideoError: ", externalVideoError);
-    }
-  }, [externalVideoData, externalVideoLoading, externalVideoError]);
-
-  const playing = externalVideoData?.meeting[0]?.externalVideo?.playerPlaying;
-  const playerCurrentTime = externalVideoData?.meeting[0]?.externalVideo?.playerCurrentTime;
-
-  const type = (() => {
-    if (/youtube\.com|youtu\.be/.test(url)) return 'youtube';
-    // if (/vimeo\.com/.test(url)) return 'vimeo';
-    // if (/twitch\.tv/.test(url)) return 'twitch';
-    // if (/dailymotion\.com/.test(url)) return 'dailymotion';
-    // if (url.endsWith('.mp4') || url.endsWith('.m3u8')) return 'mp4';
-    return 'unknown';
-  })();
+  const externalVideo = externalVideoData?.meeting?.[0]?.externalVideo;
+  const playing = externalVideo?.playerPlaying ?? false;
+  const effectivePlayerCurrentTime = calculateCurrentTime(externalVideo);
+  const isPresenter = currentUserData?.isPresenter || false;
+  const type = getPlayerType(url);
 
   useImperativeHandle(ref, () => ({
     seekTo: (sec) => playerRef.current?.seekTo?.(sec),
     play: () => playerRef.current?.play?.(),
     pause: () => playerRef.current?.pause?.(),
   }));
-
-  const calculateEffectiveTime = () => {
-    const now = Date.now();
-    const startedAt = new Date(externalVideoData?.meeting[0]?.externalVideo?.startedSharingAt).getTime();
-    const updatedAt = new Date(externalVideoData?.meeting[0]?.externalVideo?.updatedAt).getTime();
-    const currentTime = externalVideoData?.meeting[0]?.externalVideo?.playerCurrentTime;
-
-    if (now - updatedAt < 1000) {
-      return currentTime;
-    }
-
-    return currentTime + (now - startedAt) / 1000;
-  };
-
-  const effectivePlayerCurrentTime = calculateEffectiveTime();
 
   if (type === 'youtube') {
     return (
@@ -64,20 +68,32 @@ const ExternalVideo = forwardRef(({ url }, ref) => {
         url={url}
         playing={playing}
         playerCurrentTime={effectivePlayerCurrentTime}
-        isPresenter={currentUserData?.isPresenter || false}
+        isPresenter={isPresenter}
       />
     );
-  };
+  }
+
+  if (type === 'eduplay') {
+    return (
+      <EduplayPlayer
+        ref={playerRef}
+        url={url}
+        playing={playing}
+        playerCurrentTime={effectivePlayerCurrentTime}
+        isPresenter={isPresenter}
+      />
+    );
+  }
 
   if (type === 'unknown') {
     return (
       <Styled.Container>
         <Styled.Card>
-          <Styled.Text>{t("app.externalVideo.unsupported")}</Styled.Text>
+          <Styled.Text>{t('app.externalVideo.unsupported')}</Styled.Text>
         </Styled.Card>
       </Styled.Container>
     );
-  };
+  }
 
   const embedUrl = (() => {
     if (type === 'vimeo') return url.replace('vimeo.com', 'player.vimeo.com/video');

--- a/src/components/external-video/players/eduplay.js
+++ b/src/components/external-video/players/eduplay.js
@@ -1,0 +1,155 @@
+import {
+  forwardRef, useEffect, useImperativeHandle, useRef, useState,
+} from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
+import Styled from './styles';
+
+// Mirrors the Eduplay custom player from mconf-live
+// (bigbluebutton-html5/.../external-video-player/custom-players/eduplay.jsx).
+// The embed page is loaded inside an iframe of a small wrapper page, exactly
+// like the web client does, and the wrapper relays postMessage traffic in both
+// directions between the iframe and React Native.
+const MATCH_URL = /https?:\/\/(hmg\.|tst\.)?(eduplay\.rnp\.br)\/(app|portal)\/(videolive|video|tv|channel|radio|podcast)\/(.*)/;
+
+const canPlay = (url) => MATCH_URL.test(url);
+
+const parseUrl = (url) => {
+  const m = url.match(MATCH_URL);
+  if (!m) return null;
+
+  return {
+    host: `https://${m[1] || ''}${m[2]}`,
+    videoType: m[4],
+    videoId: m[5],
+  };
+};
+
+// Viewers get the `/remote-control` embed so play/pause/seek can be driven
+// from the meeting state; the presenter gets the regular embed with its own
+// controls (same as `eduplay.remoteControl: !showControls` on the web).
+const getEmbedUrl = (url, { remoteControl }) => {
+  const parsed = parseUrl(url);
+  if (!parsed) return null;
+
+  const { host, videoType, videoId } = parsed;
+  return `${host}/portal/${videoType}/embed/${videoId}${remoteControl ? '/remote-control' : ''}`;
+};
+
+const EduplayPlayer = forwardRef(({
+  url, playing, playerCurrentTime, isPresenter,
+}, ref) => {
+  const webViewRef = useRef();
+  const [ready, setReady] = useState(false);
+  const remoteControl = !isPresenter;
+  const parsed = parseUrl(url);
+  const embedUrl = getEmbedUrl(url, { remoteControl });
+
+  const sendToPlayer = (obj) => {
+    if (!remoteControl || !webViewRef.current) return;
+    webViewRef.current.injectJavaScript(
+      `try { sendToPlayer(${JSON.stringify(obj)}); } catch (e) {} true;`,
+    );
+  };
+
+  useImperativeHandle(ref, () => ({
+    seekTo: (sec) => sendToPlayer({ event: 'seek', playerPosition: sec }),
+    play: () => sendToPlayer({ event: 'play' }),
+    pause: () => sendToPlayer({ event: 'pause' }),
+  }));
+
+  useEffect(() => {
+    if (!ready) return;
+
+    if (playerCurrentTime != null) {
+      sendToPlayer({ event: 'seek', playerPosition: playerCurrentTime });
+    }
+    sendToPlayer({ event: playing ? 'play' : 'pause' });
+  }, [ready, playerCurrentTime, playing]);
+
+  const handleMessage = (event) => {
+    try {
+      const msg = JSON.parse(event.nativeEvent.data);
+      if (msg.type === 'ready') setReady(true);
+    } catch {
+      // ignore non-JSON messages from the page
+    }
+  };
+
+  if (!parsed || !embedUrl) return null;
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="referrer" content="strict-origin-when-cross-origin">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+          html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: black; overflow: hidden; }
+          iframe { width: 100%; height: 100%; border: 0; }
+        </style>
+      </head>
+      <body>
+        <iframe
+          id="player"
+          src="${embedUrl}"
+          allow="autoplay; fullscreen; encrypted-media"
+          allowfullscreen
+          scrolling="no"
+        ></iframe>
+        <script>
+          var PLAYER_ORIGIN = '${parsed.host}';
+
+          function sendToPlayer(obj) {
+            var frame = document.getElementById('player');
+            if (frame && frame.contentWindow) {
+              frame.contentWindow.postMessage(JSON.stringify(obj), '*');
+            }
+          }
+
+          // Relay player events (onPlay/onPause/onSeek/onTime) to React Native.
+          window.addEventListener('message', function (e) {
+            if (e.origin !== PLAYER_ORIGIN) return;
+            if (e.data && e.data.command) return;
+            var payload = typeof e.data === 'string' ? e.data : JSON.stringify(e.data);
+            window.ReactNativeWebView.postMessage(payload);
+          }, false);
+
+          document.getElementById('player').addEventListener('load', function () {
+            window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ready' }));
+          });
+        </script>
+      </body>
+    </html>
+  `;
+
+  return (
+    <Styled.Container>
+      <SafeAreaView style={styles.safe}>
+        <WebView
+          ref={webViewRef}
+          style={styles.webview}
+          javaScriptEnabled
+          domStorageEnabled
+          allowsInlineMediaPlayback
+          allowsFullscreenVideo
+          mediaPlaybackRequiresUserAction={false}
+          source={{ html, baseUrl: parsed.host }}
+          onMessage={handleMessage}
+        />
+      </SafeAreaView>
+    </Styled.Container>
+  );
+});
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+  },
+  webview: {
+    flex: 1,
+  },
+});
+
+export { canPlay, getEmbedUrl, MATCH_URL };
+export default EduplayPlayer;

--- a/src/components/external-video/players/youtube.js
+++ b/src/components/external-video/players/youtube.js
@@ -1,18 +1,32 @@
-import { forwardRef, useRef, useEffect, useState } from 'react';
-import { SafeAreaView, StyleSheet } from 'react-native';
+import {
+  forwardRef, useRef, useEffect, useImperativeHandle, useState,
+} from 'react';
+import {
+  SafeAreaView, StyleSheet, Dimensions, Platform,
+} from 'react-native';
 import { WebView } from 'react-native-webview';
-import { Dimensions } from 'react-native';
+import { useSelector } from 'react-redux';
+import Slider from '@react-native-community/slider';
+import { MaterialIcons } from '@expo/vector-icons';
 import Styled from './styles';
 import Colors from '../../../constants/colors';
-import Slider from '@react-native-community/slider';
-import { Platform } from 'react-native';
-import { MaterialIcons } from '@expo/vector-icons';
+import logger from '../../../services/logger';
 
 const { width } = Dimensions.get('window');
 
+// YouTube's embedded player refuses to load (error 153, "Video player
+// configuration error") when the embedding page has no https origin/Referer.
+// Inline HTML in a WebView has a null origin, so the page must be given a
+// `baseUrl`. We use the meeting host, mirroring what the web client sends.
+const FALLBACK_EMBED_ORIGIN = 'https://www.youtube.com';
+// Same host the web client (mconf-live) uses for its YouTube embeds.
+const YOUTUBE_EMBED_HOST = 'https://www.youtube-nocookie.com';
+
 // TODO: make the overlay into a component
 // that controls volume/restart/fullscreen independent of player type
-const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter }, ref) => {
+const YoutubePlayer = forwardRef(({
+  url, playing, playerCurrentTime, isPresenter,
+}, ref) => {
   const webViewRef = useRef();
   const [ready, setReady] = useState(false);
   const videoId = url.split('v=')[1]?.split('&')[0] || url.split('/').pop();
@@ -20,11 +34,13 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
   const [volume, setVolume] = useState(0);
   const [muted, setMuted] = useState(true);
   const volumeInitialized = useRef(false);
+  const host = useSelector((state) => state.client.meetingData.host);
+  const embedOrigin = host ? `https://${host}` : FALLBACK_EMBED_ORIGIN;
 
   const [webViewKey, setWebViewKey] = useState(0);
 
   const handleRefreshPlayer = () => {
-    setWebViewKey(prev => prev + 1);
+    setWebViewKey((prev) => prev + 1);
     setReady(false);
     volumeInitialized.current = false;
   };
@@ -45,7 +61,7 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
     }
 
     const script = commands
-      .map(cmd => `try { ${cmd} } catch(e) {}`)
+      .map((cmd) => `try { ${cmd} } catch(e) {}`)
       .join('\n');
 
     webViewRef.current.injectJavaScript(`
@@ -61,7 +77,7 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
   }, [volume, ready]);
 
   useEffect(() => {
-    if (!ready || volumeInitialized.current) return;
+    if (!ready || volumeInitialized.current) return undefined;
 
     const timeout = setTimeout(() => {
       setVolume(50);
@@ -71,6 +87,14 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
 
     return () => clearTimeout(timeout);
   }, [ready, volume]);
+
+  useImperativeHandle(ref, () => ({
+    seekTo: (sec) => webViewRef.current?.injectJavaScript(
+      `try { player.seekTo(${sec}, true); } catch (e) {} true;`,
+    ),
+    play: () => webViewRef.current?.injectJavaScript('try { player.playVideo(); } catch (e) {} true;'),
+    pause: () => webViewRef.current?.injectJavaScript('try { player.pauseVideo(); } catch (e) {} true;'),
+  }));
 
   const toggleMuteIOS = () => {
     const newMuted = !muted;
@@ -82,6 +106,90 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
     `);
   };
 
+  const handleMessage = (event) => {
+    try {
+      const msg = JSON.parse(event.nativeEvent.data);
+      if (msg.type === 'ready') setReady(true);
+      if (msg.type === 'error') {
+        logger.warn({
+          logCode: 'external_video_youtube_player_error',
+          extraInfo: { errorCode: msg.code, videoId },
+        }, `YouTube player error ${msg.code}`);
+      }
+    } catch {
+      // ignore non-JSON messages from the page
+    }
+  };
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="referrer" content="strict-origin-when-cross-origin">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+      </head>
+      <body style="margin:0;margin-top:102px;padding:0;background-color:black;">
+        <div id="player"></div>
+        <script>
+          var tag = document.createElement('script');
+          tag.src = "https://www.youtube.com/iframe_api";
+          var firstScriptTag = document.getElementsByTagName('script')[0];
+          firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+          var player;
+          function onYouTubeIframeAPIReady() {
+            player = new YT.Player('player', {
+              host: '${YOUTUBE_EMBED_HOST}',
+              height: '${width}',
+              width: '100%',
+              videoId: '${videoId}',
+              playerVars: {
+                'autoplay': 0,
+                'controls': 0,
+                'playsinline': 1,
+                'modestbranding': 1,
+                'rel': 0,
+                'mute': 1,
+                'origin': '${embedOrigin}',
+              },
+              events: {
+                'onReady': onPlayerReady,
+                'onError': onPlayerError
+              }
+            });
+          }
+
+          function onPlayerReady(event) {
+            window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ready' }));
+          }
+
+          function onPlayerError(event) {
+            window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'error', code: event.data }));
+          }
+
+          document.addEventListener('message', function(e) {
+            var data = JSON.parse(e.data);
+            if (player) {
+              if (data.type === 'play') player.playVideo();
+              if (data.type === 'pause') player.pauseVideo();
+              if (data.type === 'seek') player.seekTo(data.time, true);
+              if (data.type === 'volume') {
+                player.setVolume(data.volume);
+                if (data.volume > 0) player.unMute();
+              }
+              if (data.type === 'unmute') {
+                player.unMute();
+              }
+              if (data.type === 'mute') {
+                player.mute();
+              }
+            }
+          });
+        </script>
+      </body>
+    </html>
+  `;
+
   return (
     <Styled.Container>
       <SafeAreaView style={styles.safe}>
@@ -92,78 +200,15 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
           javaScriptEnabled
           allowsInlineMediaPlayback
           mediaPlaybackRequiresUserAction={false}
-          source={{
-            html: `
-              <!DOCTYPE html>
-              <html>
-                <body style="margin:0;margin-top:102px;padding:0;background-color:black;">
-                  <div id="player"></div>
-                  <script>
-                    var tag = document.createElement('script');
-                    tag.src = "https://www.youtube.com/iframe_api";
-                    var firstScriptTag = document.getElementsByTagName('script')[0];
-                    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-                    var player;
-                    function onYouTubeIframeAPIReady() {
-                      player = new YT.Player('player', {
-                        height: '${width}',
-                        width: '100%',
-                        videoId: '${videoId}',
-                        playerVars: {
-                        'autoplay': 0,
-                        'controls': 0,
-                        'playsinline': 1,
-                        'modestbranding': 1,
-                        'rel': 0,
-                        'mute': 1,
-                        },
-                        events: {
-                          'onReady': onPlayerReady
-                        }
-                      });
-                    }
-
-                    function onPlayerReady(event) {
-                      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ready' }));
-                    }
-
-                    document.addEventListener('message', function(e) {
-                      var data = JSON.parse(e.data);
-                      if (player) {
-                        if (data.type === 'play') player.playVideo();
-                        if (data.type === 'pause') player.pauseVideo();
-                        if (data.type === 'seek') player.seekTo(data.time, true);
-                        if (data.type === 'volume') {
-                          player.setVolume(data.volume);
-                          if (data.volume > 0) player.unMute();
-                        }
-                        if (data.type === 'unmute') {
-                          player.unMute();
-                        }
-                        if (data.type === 'mute') {
-                          player.mute();
-                        }
-                      }
-                    });
-                  </script>
-                </body>
-              </html>
-            `
-          }}
-          onMessage={event => {
-            try {
-              const msg = JSON.parse(event.nativeEvent.data);
-              if (msg.type === 'ready') setReady(true);
-            } catch { }
-          }}
+          source={{ html, baseUrl: embedOrigin }}
+          onMessage={handleMessage}
         />
         {!isPresenter && (
           <>
             <Styled.Overlay
               pointerEvents="auto"
-              onTouchStart={() => setShowVolume(v => !v)}
-              onClick={() => setShowVolume(v => !v)}
+              onTouchStart={() => setShowVolume((v) => !v)}
+              onClick={() => setShowVolume((v) => !v)}
             />
 
             <Styled.RestartIcon
@@ -199,7 +244,7 @@ const YoutubePlayer = forwardRef(({ url, playing, playerCurrentTime, isPresenter
           </>
         )}
       </SafeAreaView>
-    </Styled.Container >
+    </Styled.Container>
   );
 });
 


### PR DESCRIPTION
## Summary

Fixes #1177 (YouTube and Eduplay external videos not playing on mobile).

### YouTube: "Erro de configuração do player de vídeo" (error 153)
YouTube now rejects embedded players whose page has no https origin/Referer. Our player was built from inline HTML with no `baseUrl`, so the WebView had a null origin.
- Give the WebView a `baseUrl`/`origin` (the meeting host, fallback `https://www.youtube.com`) and a `referrer` meta tag.
- Embed through `youtube-nocookie.com`, same as the web client.
- Forward player errors to the logger; expose `play`/`pause`/`seekTo` through the component ref.

### Eduplay
Port of mconf-live's `custom-players/eduplay.jsx`:
- Detect `eduplay.rnp.br` URLs and load `{host}/portal/{type}/embed/{id}` (with `/remote-control` for viewers) inside a wrapper page in a WebView.
- Relay the play/pause/seek `postMessage` protocol between the iframe and React Native.

### Time sync
Viewer position is now computed like the web client (`playerCurrentTime` + elapsed since `updatedAt`, frozen while paused) instead of counting from `startedSharingAt`, which drifted after any pause or seek.

## Out of scope
Presenter-side controls on mobile (the start/update/stop mutations are still unused). New feature, separate issue.

## Test plan
- [ ] Android: share a YouTube video from the web client, mobile viewer plays it without the error 153 card.
- [ ] iOS: same as above.
- [ ] Pause/seek from the presenter; mobile viewer follows the new position.
- [ ] Share an Eduplay video (`https://eduplay.rnp.br/portal/video/...`); mobile viewer plays it and follows play/pause/seek.
- [ ] Unsupported URL still shows "Tipo de vídeo não suportado".

Lint is clean on the changed files and `npm run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)